### PR TITLE
V1.44

### DIFF
--- a/1.43ReadMe
+++ b/1.43ReadMe
@@ -1,6 +1,0 @@
-#V1.43 21-Apr-2019
-#	If Policies parameter is used, check to see if PowerShell session is elevated. If it is,
-#		abort the script. This is the #2 support email.
-#		Added a Note to the Help Text and ReadMe file about the Citrix.GroupPolicy.Commands module:
-#		Note: The Citrix Group Policy PowerShell module will not load from an elevated PowerShell session. 
-#		If the module is manually imported, the module is not detected from an elevated PowerShell session.

--- a/1.44ReadMe
+++ b/1.44ReadMe
@@ -1,9 +1,14 @@
-#Version 1.44
+#Version 1.44 17-Dec-2019
 #	Add a NoSessions parameter to exclude Machine Catalog, Application and Hosting session data from the report
 #	Added missing "Will shutdown after use" to the Hosting section in Function OutputMachineDetails
+#	Fix Swedish Table of Contents (Thanks to Johan Kallio)
+#		From 
+#			'sv-'	{ 'Automatisk innehållsförteckning2'; Break }
+#		To
+#			'sv-'	{ 'Automatisk innehållsförteckn2'; Break }
 #	Updated Function CheckExcelPrereq to match the V2 script
 #	Updated Function CheckWordPrereq to match the V2 script
-#	Updated Function OutputDeliveryGroupDetails  by removing unused variable $xDeliveryGroupType
+#	Updated Function OutputDeliveryGroupDetails by removing unused variable $xDeliveryGroupType
 #	Updated Function OutputDeliveryGroupUtilization to match the V2 script
 #	Updated Function OutputHosting to match the V2 script
 #	Updated Function OutputHostingSessions by removing all desktop code as it is not used
@@ -11,3 +16,4 @@
 #		Updated Function GetComputerWMIInfo to pass the computer name parameter to the OutputNicItem function
 #	Updated Function ProcessCitrixPolicies to match the V2 script
 #	Updated Function ProcessHosting to match the V2 script
+#	Updated help text

--- a/1.44ReadMe
+++ b/1.44ReadMe
@@ -1,0 +1,13 @@
+#Version 1.44
+#	Add a NoSessions parameter to exclude Machine Catalog, Application and Hosting session data from the report
+#	Added missing "Will shutdown after use" to the Hosting section in Function OutputMachineDetails
+#	Updated Function CheckExcelPrereq to match the V2 script
+#	Updated Function CheckWordPrereq to match the V2 script
+#	Updated Function OutputDeliveryGroupDetails  by removing unused variable $xDeliveryGroupType
+#	Updated Function OutputDeliveryGroupUtilization to match the V2 script
+#	Updated Function OutputHosting to match the V2 script
+#	Updated Function OutputHostingSessions by removing all desktop code as it is not used
+#	Updated Function OutputNicItem with a $ComputerName parameter
+#		Updated Function GetComputerWMIInfo to pass the computer name parameter to the OutputNicItem function
+#	Updated Function ProcessCitrixPolicies to match the V2 script
+#	Updated Function ProcessHosting to match the V2 script

--- a/XD7_Inventory.ps1
+++ b/XD7_Inventory.ps1
@@ -278,11 +278,19 @@
 		StoreFront
 
 	Does not change the value of NoADPolicies.
+	Does not change the value of NoSessions.
 	
 	WARNING: Using this parameter can create an extremely large report and 
 	can take a very long time to run.
 
 	This parameter has an alias of MAX.
+.PARAMETER NoSessions
+	Excludes Machine Catalog, Application and Hosting session data from the report.
+	
+	Using the MaxDetails parameter does not change this setting.
+	
+	This parameter is disabled by default.
+	This parameter has an alias of NS.
 .PARAMETER Policies
 	Give detailed information for both Site and Citrix AD based Policies.
 	
@@ -896,9 +904,9 @@
 	plain text or HTML document.
 .NOTES
 	NAME: XD7_Inventory.ps1
-	VERSION: 1.43
+	VERSION: 1.44
 	AUTHOR: Carl Webster
-	LASTEDIT: April 21, 2019
+	LASTEDIT: October 3, 2019
 #>
 
 #endregion
@@ -1018,6 +1026,10 @@ Param(
 	[Switch]$MaxDetails=$False,
 
 	[parameter(Mandatory=$False)] 
+	[Alias("NS")]
+	[Switch]$NoSessions=$False,	
+	
+	[parameter(Mandatory=$False)] 
 	[Alias("Pol")]
 	[Switch]$Policies=$False,	
 	
@@ -1083,7 +1095,21 @@ Param(
 
 # Version 1.0 released to the community on June 12, 2015
 
-#V1.43 21-Apr-2019
+#Version 1.44
+#	Add a NoSessions parameter to exclude Machine Catalog, Application and Hosting session data from the report
+#	Added missing "Will shutdown after use" to the Hosting section in Function OutputMachineDetails
+#	Updated Function CheckExcelPrereq to match the V2 script
+#	Updated Function CheckWordPrereq to match the V2 script
+#	Updated Function OutputDeliveryGroupDetails  by removing unused variable $xDeliveryGroupType
+#	Updated Function OutputDeliveryGroupUtilization to match the V2 script
+#	Updated Function OutputHosting to match the V2 script
+#	Updated Function OutputHostingSessions by removing all desktop code as it is not used
+#	Updated Function OutputNicItem with a $ComputerName parameter
+#		Updated Function GetComputerWMIInfo to pass the computer name parameter to the OutputNicItem function
+#	Updated Function ProcessCitrixPolicies to match the V2 script
+#	Updated Function ProcessHosting to match the V2 script
+#
+#Version1.43 21-Apr-2019
 #	If Policies parameter is used, check to see if PowerShell session is elevated. If it is,
 #		abort the script. This is the #2 support email.
 #		Added a Note to the Help Text and ReadMe file about the Citrix.GroupPolicy.Commands module:
@@ -1755,7 +1781,7 @@ Function GetComputerWMIInfo
 	# http://blog.myvirtualvision.com
 	# modified 1-May-2014 to work in trusted AD Forests and using different domain admin credentials	
 	# modified 17-Aug-2016 to fix a few issues with Text and HTML output
-	# modified 2-Apr-2018 to add ComputerOS information
+	# modified 29-Apr-2018 to change from Arrays to New-Object System.Collections.ArrayList
 
 	#Get Computer info
 	Write-Verbose "$(Get-Date): `t`tProcessing WMI Computer information"
@@ -1775,8 +1801,6 @@ Function GetComputerWMIInfo
 		WriteHTMLLine 3 0 "Computer Information: $($RemoteComputerName)"
 		WriteHTMLLine 4 0 "General Computer"
 	}
-	
-	[bool]$GotComputerItems = $True
 	
 	Try
 	{
@@ -1822,10 +1846,10 @@ Function GetComputerWMIInfo
 		}
 		ElseIf($HTML)
 		{
-			WriteHTMLLine 0 2 "Get-WmiObject win32_computersystem failed for $($RemoteComputerName)" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
+			WriteHTMLLine 0 2 "Get-WmiObject win32_computersystem failed for $($RemoteComputerName)" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 2 $htmlbold
 		}
 	}
 	Else
@@ -1841,7 +1865,7 @@ Function GetComputerWMIInfo
 		}
 		ElseIf($HTML)
 		{
-			WriteHTMLLine 0 2 "No results Returned for Computer information" "" $Null 0 $False $True
+			WriteHTMLLine 0 2 "No results Returned for Computer information" "" "" $Null 2 $htmlbold
 		}
 	}
 	
@@ -1861,8 +1885,6 @@ Function GetComputerWMIInfo
 		WriteHTMLLine 4 0 "Drive(s)"
 	}
 
-	[bool]$GotDrives = $True
-	
 	Try
 	{
 		$Results = Get-WmiObject -computername $RemoteComputerName Win32_LogicalDisk
@@ -1907,10 +1929,10 @@ Function GetComputerWMIInfo
 		}
 		ElseIf($HTML)
 		{
-			WriteHTMLLine 0 2 "Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
+			WriteHTMLLine 0 2 "Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 2 $htmlbold
 		}
 	}
 	Else
@@ -1926,7 +1948,7 @@ Function GetComputerWMIInfo
 		}
 		ElseIf($HTML)
 		{
-			WriteHTMLLine 0 2 "No results Returned for Drive information" "" $Null 0 $False $True
+			WriteHTMLLine 0 2 "No results Returned for Drive information" "" $Null 2 $htmlbold
 		}
 	}
 	
@@ -1947,8 +1969,6 @@ Function GetComputerWMIInfo
 		WriteHTMLLine 4 0 "Processor(s)"
 	}
 
-	[bool]$GotProcessors = $True
-	
 	Try
 	{
 		$Results = Get-WmiObject -computername $RemoteComputerName win32_Processor
@@ -1989,10 +2009,10 @@ Function GetComputerWMIInfo
 		}
 		ElseIf($HTML)
 		{
-			WriteHTMLLine 0 2 "Get-WmiObject win32_Processor failed for $($RemoteComputerName)" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
+			WriteHTMLLine 0 2 "Get-WmiObject win32_Processor failed for $($RemoteComputerName)" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 2 $htmlbold
 		}
 	}
 	Else
@@ -2008,7 +2028,7 @@ Function GetComputerWMIInfo
 		}
 		ElseIf($HTML)
 		{
-			WriteHTMLLine 0 2 "No results Returned for Processor information" "" $Null 0 $False $True
+			WriteHTMLLine 0 2 "No results Returned for Processor information" "" $Null 2 $htmlbold
 		}
 	}
 
@@ -2045,7 +2065,7 @@ Function GetComputerWMIInfo
 		$Nics = $Results | Where-Object {$Null -ne $_.ipaddress}
 		$Results = $Null
 
-		If($Nics -eq $Null ) 
+		If($Null -eq $Nics) 
 		{ 
 			$GotNics = $False 
 		} 
@@ -2070,7 +2090,7 @@ Function GetComputerWMIInfo
 				
 				If($? -and $Null -ne $ThisNic)
 				{
-					OutputNicItem $Nic $ThisNic
+					OutputNicItem $Nic $ThisNic $RemoteComputerName
 				}
 				ElseIf(!$?)
 				{
@@ -2096,10 +2116,10 @@ Function GetComputerWMIInfo
 					ElseIf($HTML)
 					{
 						WriteHTMLLine 0 2 "Error retrieving NIC information" "" $Null 0 $False $True
-						WriteHTMLLine 0 2 "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)" "" $Null 0 $False $True
-						WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-						WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-						WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
+						WriteHTMLLine 0 2 "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)" "" $Null 2 $htmlbold
+						WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 2 $htmlbold
+						WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 2 $htmlbold
+						WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 2 $htmlbold
 					}
 				}
 				Else
@@ -2115,7 +2135,7 @@ Function GetComputerWMIInfo
 					}
 					ElseIf($HTML)
 					{
-						WriteHTMLLine 0 2 "No results Returned for NIC information" "" $Null 0 $False $True
+						WriteHTMLLine 0 2 "No results Returned for NIC information" "" $Null 2 $htmlbold
 					}
 				}
 			}
@@ -2144,11 +2164,11 @@ Function GetComputerWMIInfo
 		}
 		ElseIf($HTML)
 		{
-			WriteHTMLLine 0 2 "Error retrieving NIC configuration information" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 0 $False $True
-			WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 0 $False $True
+			WriteHTMLLine 0 2 "Error retrieving NIC configuration information" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "On $($RemoteComputerName) you may need to run winmgmt /verifyrepository" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "and winmgmt /salvagerepository.  If this is a trusted Forest, you may" "" $Null 2 $htmlbold
+			WriteHTMLLine 0 2 "need to rerun the script with Domain Admin credentials from the trusted Forest." "" $Null 2 $htmlbold
 		}
 	}
 	Else
@@ -2164,7 +2184,7 @@ Function GetComputerWMIInfo
 		}
 		ElseIf($HTML)
 		{
-			WriteHTMLLine 0 2 "No results Returned for NIC configuration information" "" $Null 0 $False $True
+			WriteHTMLLine 0 2 "No results Returned for NIC configuration information" "" $Null 2 $htmlbold
 		}
 	}
 	
@@ -2185,18 +2205,17 @@ Function GetComputerWMIInfo
 Function OutputComputerItem
 {
 	Param([object]$Item, [string]$OS)
-	# modified 2-Apr-2018 to add Operating System information
 	
 	If($MSWord -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $ItemInformation = @()
-		$ItemInformation += @{ Data = "Manufacturer"; Value = $Item.manufacturer; }
-		$ItemInformation += @{ Data = "Model"; Value = $Item.model; }
-		$ItemInformation += @{ Data = "Domain"; Value = $Item.domain; }
-		$ItemInformation += @{ Data = "Operating System"; Value = $OS; }
-		$ItemInformation += @{ Data = "Total Ram"; Value = "$($Item.totalphysicalram) GB"; }
-		$ItemInformation += @{ Data = "Physical Processors (sockets)"; Value = $Item.NumberOfProcessors; }
-		$ItemInformation += @{ Data = "Logical Processors (cores w/HT)"; Value = $Item.NumberOfLogicalProcessors; }
+		$ItemInformation = New-Object System.Collections.ArrayList
+		$ItemInformation.Add(@{ Data = "Manufacturer"; Value = $Item.manufacturer; }) > $Null
+		$ItemInformation.Add(@{ Data = "Model"; Value = $Item.model; }) > $Null
+		$ItemInformation.Add(@{ Data = "Domain"; Value = $Item.domain; }) > $Null
+		$ItemInformation.Add(@{ Data = "Operating System"; Value = $OS; }) > $Null
+		$ItemInformation.Add(@{ Data = "Total Ram"; Value = "$($Item.totalphysicalram) GB"; }) > $Null
+		$ItemInformation.Add(@{ Data = "Physical Processors (sockets)"; Value = $Item.NumberOfProcessors; }) > $Null
+		$ItemInformation.Add(@{ Data = "Logical Processors (cores w/HT)"; Value = $Item.NumberOfLogicalProcessors; }) > $Null
 		$Table = AddWordTable -Hashtable $ItemInformation `
 		-Columns Data,Value `
 		-List `
@@ -2251,13 +2270,13 @@ Function OutputDriveItem
 	$xDriveType = ""
 	Switch ($drive.drivetype)
 	{
-		0		{$xDriveType = "Unknown"; Break}
-		1		{$xDriveType = "No Root Directory"; Break}
-		2		{$xDriveType = "Removable Disk"; Break}
-		3		{$xDriveType = "Local Disk"; Break}
-		4		{$xDriveType = "Network Drive"; Break}
-		5		{$xDriveType = "Compact Disc"; Break}
-		6		{$xDriveType = "RAM Disk"; Break}
+		0	{$xDriveType = "Unknown"; Break}
+		1	{$xDriveType = "No Root Directory"; Break}
+		2	{$xDriveType = "Removable Disk"; Break}
+		3	{$xDriveType = "Local Disk"; Break}
+		4	{$xDriveType = "Network Drive"; Break}
+		5	{$xDriveType = "Compact Disc"; Break}
+		6	{$xDriveType = "RAM Disk"; Break}
 		Default {$xDriveType = "Unknown"; Break}
 	}
 	
@@ -2276,27 +2295,27 @@ Function OutputDriveItem
 
 	If($MSWORD -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $DriveInformation = @()
-		$DriveInformation += @{ Data = "Caption"; Value = $Drive.caption; }
-		$DriveInformation += @{ Data = "Size"; Value = "$($drive.drivesize) GB"; }
+		$DriveInformation = New-Object System.Collections.ArrayList
+		$DriveInformation.Add(@{ Data = "Caption"; Value = $Drive.caption; }) > $Null
+		$DriveInformation.Add(@{ Data = "Size"; Value = "$($drive.drivesize) GB"; }) > $Null
 		If(![String]::IsNullOrEmpty($drive.filesystem))
 		{
-			$DriveInformation += @{ Data = "File System"; Value = $Drive.filesystem; }
+			$DriveInformation.Add(@{ Data = "File System"; Value = $Drive.filesystem; }) > $Null
 		}
-		$DriveInformation += @{ Data = "Free Space"; Value = "$($drive.drivefreespace) GB"; }
+		$DriveInformation.Add(@{ Data = "Free Space"; Value = "$($drive.drivefreespace) GB"; }) > $Null
 		If(![String]::IsNullOrEmpty($drive.volumename))
 		{
-			$DriveInformation += @{ Data = "Volume Name"; Value = $Drive.volumename; }
+			$DriveInformation.Add(@{ Data = "Volume Name"; Value = $Drive.volumename; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($drive.volumedirty))
 		{
-			$DriveInformation += @{ Data = "Volume is Dirty"; Value = $xVolumeDirty; }
+			$DriveInformation.Add(@{ Data = "Volume is Dirty"; Value = $xVolumeDirty; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($drive.volumeserialnumber))
 		{
-			$DriveInformation += @{ Data = "Volume Serial Number"; Value = $Drive.volumeserialnumber; }
+			$DriveInformation.Add(@{ Data = "Volume Serial Number"; Value = $Drive.volumeserialnumber; }) > $Null
 		}
-		$DriveInformation += @{ Data = "Drive Type"; Value = $xDriveType; }
+		$DriveInformation.Add(@{ Data = "Drive Type"; Value = $xDriveType; }) > $Null
 		$Table = AddWordTable -Hashtable $DriveInformation `
 		-Columns Data,Value `
 		-List `
@@ -2368,8 +2387,8 @@ Function OutputDriveItem
 
 		$msg = ""
 		$columnWidths = @("150px","200px")
-		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths
+		WriteHTMLLine 0 0 ""
 	}
 }
 
@@ -2380,49 +2399,49 @@ Function OutputProcessorItem
 	$xAvailability = ""
 	Switch ($processor.availability)
 	{
-		1		{$xAvailability = "Other"; Break}
-		2		{$xAvailability = "Unknown"; Break}
-		3		{$xAvailability = "Running or Full Power"; Break}
-		4		{$xAvailability = "Warning"; Break}
-		5		{$xAvailability = "In Test"; Break}
-		6		{$xAvailability = "Not Applicable"; Break}
-		7		{$xAvailability = "Power Off"; Break}
-		8		{$xAvailability = "Off Line"; Break}
-		9		{$xAvailability = "Off Duty"; Break}
-		10		{$xAvailability = "Degraded"; Break}
-		11		{$xAvailability = "Not Installed"; Break}
-		12		{$xAvailability = "Install Error"; Break}
-		13		{$xAvailability = "Power Save - Unknown"; Break}
-		14		{$xAvailability = "Power Save - Low Power Mode"; Break}
-		15		{$xAvailability = "Power Save - Standby"; Break}
-		16		{$xAvailability = "Power Cycle"; Break}
-		17		{$xAvailability = "Power Save - Warning"; Break}
+		1	{$xAvailability = "Other"; Break}
+		2	{$xAvailability = "Unknown"; Break}
+		3	{$xAvailability = "Running or Full Power"; Break}
+		4	{$xAvailability = "Warning"; Break}
+		5	{$xAvailability = "In Test"; Break}
+		6	{$xAvailability = "Not Applicable"; Break}
+		7	{$xAvailability = "Power Off"; Break}
+		8	{$xAvailability = "Off Line"; Break}
+		9	{$xAvailability = "Off Duty"; Break}
+		10	{$xAvailability = "Degraded"; Break}
+		11	{$xAvailability = "Not Installed"; Break}
+		12	{$xAvailability = "Install Error"; Break}
+		13	{$xAvailability = "Power Save - Unknown"; Break}
+		14	{$xAvailability = "Power Save - Low Power Mode"; Break}
+		15	{$xAvailability = "Power Save - Standby"; Break}
+		16	{$xAvailability = "Power Cycle"; Break}
+		17	{$xAvailability = "Power Save - Warning"; Break}
 		Default	{$xAvailability = "Unknown"; Break}
 	}
 
 	If($MSWORD -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $ProcessorInformation = @()
-		$ProcessorInformation += @{ Data = "Name"; Value = $Processor.name; }
-		$ProcessorInformation += @{ Data = "Description"; Value = $Processor.description; }
-		$ProcessorInformation += @{ Data = "Max Clock Speed"; Value = "$($processor.maxclockspeed) MHz"; }
+		$ProcessorInformation = New-Object System.Collections.ArrayList
+		$ProcessorInformation.Add(@{ Data = "Name"; Value = $Processor.name; }) > $Null
+		$ProcessorInformation.Add(@{ Data = "Description"; Value = $Processor.description; }) > $Null
+		$ProcessorInformation.Add(@{ Data = "Max Clock Speed"; Value = "$($processor.maxclockspeed) MHz"; }) > $Null
 		If($processor.l2cachesize -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "L2 Cache Size"; Value = "$($processor.l2cachesize) KB"; }
+			$ProcessorInformation.Add(@{ Data = "L2 Cache Size"; Value = "$($processor.l2cachesize) KB"; }) > $Null
 		}
 		If($processor.l3cachesize -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "L3 Cache Size"; Value = "$($processor.l3cachesize) KB"; }
+			$ProcessorInformation.Add(@{ Data = "L3 Cache Size"; Value = "$($processor.l3cachesize) KB"; }) > $Null
 		}
 		If($processor.numberofcores -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "Number of Cores"; Value = $Processor.numberofcores; }
+			$ProcessorInformation.Add(@{ Data = "Number of Cores"; Value = $Processor.numberofcores; }) > $Null
 		}
 		If($processor.numberoflogicalprocessors -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "Number of Logical Processors (cores w/HT)"; Value = $Processor.numberoflogicalprocessors; }
+			$ProcessorInformation.Add(@{ Data = "Number of Logical Processors (cores w/HT)"; Value = $Processor.numberoflogicalprocessors; }) > $Null
 		}
-		$ProcessorInformation += @{ Data = "Availability"; Value = $xAvailability; }
+		$ProcessorInformation.Add(@{ Data = "Availability"; Value = $xAvailability; }) > $Null
 		$Table = AddWordTable -Hashtable $ProcessorInformation `
 		-Columns Data,Value `
 		-List `
@@ -2492,53 +2511,66 @@ Function OutputProcessorItem
 
 		$msg = ""
 		$columnWidths = @("150px","200px")
-		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths
+		WriteHTMLLine 0 0 ""
 	}
 }
 
 Function OutputNicItem
 {
-	Param([object]$Nic, [object]$ThisNic)
+	Param([object]$Nic, [object]$ThisNic, [string] $ComputerName)
 	
-	$powerMgmt = Get-WmiObject MSPower_DeviceEnable -Namespace root\wmi | Where-Object {$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
-
-	If($? -and $Null -ne $powerMgmt)
+	#V2.23 change how $powerMgmt is retrieved
+	If(validObject $ThisNic PowerManagementSupported)
 	{
-		If($powerMgmt.Enable -eq $True)
+		$powerMgmt = $ThisNic.PowerManagementSupported
+	}
+	
+	If($powerMgmt)
+	{
+		$powerMgmt = Get-WmiObject -ComputerName MSPower_DeviceEnable -Namespace root\wmi | Where-Object {$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
+
+		If($? -and $Null -ne $powerMgmt)
 		{
-			$PowerSaving = "Enabled"
+			If($powerMgmt.Enable -eq $True)
+			{
+				$PowerSaving = "Enabled"
+			}
+			Else
+			{
+				$PowerSaving = "Disabled"
+			}
 		}
 		Else
 		{
-			$PowerSaving = "Disabled"
+			$PowerSaving = "N/A"
 		}
 	}
 	Else
 	{
-        $PowerSaving = "N/A"
+		$PowerSaving = "Not Supported"
 	}
 	
 	$xAvailability = ""
 	Switch ($processor.availability)
 	{
-		1		{$xAvailability = "Other"; Break}
-		2		{$xAvailability = "Unknown"; Break}
-		3		{$xAvailability = "Running or Full Power"; Break}
-		4		{$xAvailability = "Warning"; Break}
-		5		{$xAvailability = "In Test"; Break}
-		6		{$xAvailability = "Not Applicable"; Break}
-		7		{$xAvailability = "Power Off"; Break}
-		8		{$xAvailability = "Off Line"; Break}
-		9		{$xAvailability = "Off Duty"; Break}
-		10		{$xAvailability = "Degraded"; Break}
-		11		{$xAvailability = "Not Installed"; Break}
-		12		{$xAvailability = "Install Error"; Break}
-		13		{$xAvailability = "Power Save - Unknown"; Break}
-		14		{$xAvailability = "Power Save - Low Power Mode"; Break}
-		15		{$xAvailability = "Power Save - Standby"; Break}
-		16		{$xAvailability = "Power Cycle"; Break}
-		17		{$xAvailability = "Power Save - Warning"; Break}
+		1	{$xAvailability = "Other"; Break}
+		2	{$xAvailability = "Unknown"; Break}
+		3	{$xAvailability = "Running or Full Power"; Break}
+		4	{$xAvailability = "Warning"; Break}
+		5	{$xAvailability = "In Test"; Break}
+		6	{$xAvailability = "Not Applicable"; Break}
+		7	{$xAvailability = "Power Off"; Break}
+		8	{$xAvailability = "Off Line"; Break}
+		9	{$xAvailability = "Off Duty"; Break}
+		10	{$xAvailability = "Degraded"; Break}
+		11	{$xAvailability = "Not Installed"; Break}
+		12	{$xAvailability = "Install Error"; Break}
+		13	{$xAvailability = "Power Save - Unknown"; Break}
+		14	{$xAvailability = "Power Save - Low Power Mode"; Break}
+		15	{$xAvailability = "Power Save - Standby"; Break}
+		16	{$xAvailability = "Power Cycle"; Break}
+		17	{$xAvailability = "Power Save - Warning"; Break}
 		Default	{$xAvailability = "Unknown"; Break}
 	}
 
@@ -2557,10 +2589,10 @@ Function OutputNicItem
 	If($Null -ne $nic.dnsdomainsuffixsearchorder -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
 	{
 		$nicdnsdomainsuffixsearchorder = $nic.dnsdomainsuffixsearchorder
-		$xnicdnsdomainsuffixsearchorder = @()
+		$xnicdnsdomainsuffixsearchorder = New-Object System.Collections.ArrayList
 		ForEach($DNSDomain in $nicdnsdomainsuffixsearchorder)
 		{
-			$xnicdnsdomainsuffixsearchorder += "$($DNSDomain)"
+			$xnicdnsdomainsuffixsearchorder.Add("$($DNSDomain)") > $Null
 		}
 	}
 	
@@ -2587,9 +2619,9 @@ Function OutputNicItem
 	$xTcpipNetbiosOptions = ""
 	Switch ($nic.TcpipNetbiosOptions)
 	{
-		0		{$xTcpipNetbiosOptions = "Use NetBIOS setting from DHCP Server"; Break}
-		1		{$xTcpipNetbiosOptions = "Enable NetBIOS"; Break}
-		2		{$xTcpipNetbiosOptions = "Disable NetBIOS"; Break}
+		0	{$xTcpipNetbiosOptions = "Use NetBIOS setting from DHCP Server"; Break}
+		1	{$xTcpipNetbiosOptions = "Enable NetBIOS"; Break}
+		2	{$xTcpipNetbiosOptions = "Disable NetBIOS"; Break}
 		Default	{$xTcpipNetbiosOptions = "Unknown"; Break}
 	}
 	
@@ -2605,99 +2637,99 @@ Function OutputNicItem
 
 	If($MSWORD -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $NicInformation = @()
-		$NicInformation += @{ Data = "Name"; Value = $ThisNic.Name; }
+		$NicInformation = New-Object System.Collections.ArrayList
+		$NicInformation.Add(@{ Data = "Name"; Value = $ThisNic.Name; }) > $Null
 		If($ThisNic.Name -ne $nic.description)
 		{
-			$NicInformation += @{ Data = "Description"; Value = $Nic.description; }
+			$NicInformation.Add(@{ Data = "Description"; Value = $Nic.description; }) > $Null
 		}
-		$NicInformation += @{ Data = "Connection ID"; Value = $ThisNic.NetConnectionID; }
+		$NicInformation.Add(@{ Data = "Connection ID"; Value = $ThisNic.NetConnectionID; }) > $Null
 		If(validObject $Nic Manufacturer)
 		{
-			$NicInformation += @{ Data = "Manufacturer"; Value = $Nic.manufacturer; }
+			$NicInformation.Add(@{ Data = "Manufacturer"; Value = $Nic.manufacturer; }) > $Null
 		}
-		$NicInformation += @{ Data = "Availability"; Value = $xAvailability; }
-		$NicInformation += @{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }
-		$NicInformation += @{ Data = "Physical Address"; Value = $Nic.macaddress; }
+		$NicInformation.Add(@{ Data = "Availability"; Value = $xAvailability; }) > $Null
+		$NicInformation.Add(@{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }) > $Null
+		$NicInformation.Add(@{ Data = "Physical Address"; Value = $Nic.macaddress; }) > $Null
 		If($xIPAddress.Count -gt 1)
 		{
-			$NicInformation += @{ Data = "IP Address"; Value = $xIPAddress[0]; }
-			$NicInformation += @{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }
-			$NicInformation += @{ Data = "Subnet Mask"; Value = $xIPSubnet[0]; }
+			$NicInformation.Add(@{ Data = "IP Address"; Value = $xIPAddress[0]; }) > $Null
+			$NicInformation.Add(@{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }) > $Null
+			$NicInformation.Add(@{ Data = "Subnet Mask"; Value = $xIPSubnet[0]; }) > $Null
 			$cnt = -1
 			ForEach($tmp in $xIPAddress)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$NicInformation += @{ Data = "IP Address"; Value = $tmp; }
-					$NicInformation += @{ Data = "Subnet Mask"; Value = $xIPSubnet[$cnt]; }
+					$NicInformation.Add(@{ Data = "IP Address"; Value = $tmp; }) > $Null
+					$NicInformation.Add(@{ Data = "Subnet Mask"; Value = $xIPSubnet[$cnt]; }) > $Null
 				}
 			}
 		}
 		Else
 		{
-			$NicInformation += @{ Data = "IP Address"; Value = $xIPAddress; }
-			$NicInformation += @{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }
-			$NicInformation += @{ Data = "Subnet Mask"; Value = $xIPSubnet; }
+			$NicInformation.Add(@{ Data = "IP Address"; Value = $xIPAddress; }) > $Null
+			$NicInformation.Add(@{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }) > $Null
+			$NicInformation.Add(@{ Data = "Subnet Mask"; Value = $xIPSubnet; }) > $Null
 		}
 		If($nic.dhcpenabled)
 		{
 			$DHCPLeaseObtainedDate = $nic.ConvertToDateTime($nic.dhcpleaseobtained)
 			$DHCPLeaseExpiresDate = $nic.ConvertToDateTime($nic.dhcpleaseexpires)
-			$NicInformation += @{ Data = "DHCP Enabled"; Value = $Nic.dhcpenabled; }
-			$NicInformation += @{ Data = "DHCP Lease Obtained"; Value = $dhcpleaseobtaineddate; }
-			$NicInformation += @{ Data = "DHCP Lease Expires"; Value = $dhcpleaseexpiresdate; }
-			$NicInformation += @{ Data = "DHCP Server"; Value = $Nic.dhcpserver; }
+			$NicInformation.Add(@{ Data = "DHCP Enabled"; Value = $Nic.dhcpenabled; }) > $Null
+			$NicInformation.Add(@{ Data = "DHCP Lease Obtained"; Value = $dhcpleaseobtaineddate; }) > $Null
+			$NicInformation.Add(@{ Data = "DHCP Lease Expires"; Value = $dhcpleaseexpiresdate; }) > $Null
+			$NicInformation.Add(@{ Data = "DHCP Server"; Value = $Nic.dhcpserver; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.dnsdomain))
 		{
-			$NicInformation += @{ Data = "DNS Domain"; Value = $Nic.dnsdomain; }
+			$NicInformation.Add(@{ Data = "DNS Domain"; Value = $Nic.dnsdomain; }) > $Null
 		}
 		If($Null -ne $nic.dnsdomainsuffixsearchorder -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
 		{
-			$NicInformation += @{ Data = "DNS Search Suffixes"; Value = $xnicdnsdomainsuffixsearchorder[0]; }
+			$NicInformation.Add(@{ Data = "DNS Search Suffixes"; Value = $xnicdnsdomainsuffixsearchorder[0]; }) > $Null
 			$cnt = -1
 			ForEach($tmp in $xnicdnsdomainsuffixsearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$NicInformation += @{ Data = ""; Value = $tmp; }
+					$NicInformation.Add(@{ Data = ""; Value = $tmp; }) > $Null
 				}
 			}
 		}
-		$NicInformation += @{ Data = "DNS WINS Enabled"; Value = $xdnsenabledforwinsresolution; }
+		$NicInformation.Add(@{ Data = "DNS WINS Enabled"; Value = $xdnsenabledforwinsresolution; }) > $Null
 		If($Null -ne $nic.dnsserversearchorder -and $nic.dnsserversearchorder.length -gt 0)
 		{
-			$NicInformation += @{ Data = "DNS Servers"; Value = $xnicdnsserversearchorder[0]; }
+			$NicInformation.Add(@{ Data = "DNS Servers"; Value = $xnicdnsserversearchorder[0]; }) > $Null
 			$cnt = -1
 			ForEach($tmp in $xnicdnsserversearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$NicInformation += @{ Data = ""; Value = $tmp; }
+					$NicInformation.Add(@{ Data = ""; Value = $tmp; }) > $Null
 				}
 			}
 		}
-		$NicInformation += @{ Data = "NetBIOS Setting"; Value = $xTcpipNetbiosOptions; }
-		$NicInformation += @{ Data = "WINS: Enabled LMHosts"; Value = $xwinsenablelmhostslookup; }
+		$NicInformation.Add(@{ Data = "NetBIOS Setting"; Value = $xTcpipNetbiosOptions; }) > $Null
+		$NicInformation.Add(@{ Data = "WINS: Enabled LMHosts"; Value = $xwinsenablelmhostslookup; }) > $Null
 		If(![String]::IsNullOrEmpty($nic.winshostlookupfile))
 		{
-			$NicInformation += @{ Data = "Host Lookup File"; Value = $Nic.winshostlookupfile; }
+			$NicInformation.Add(@{ Data = "Host Lookup File"; Value = $Nic.winshostlookupfile; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winsprimaryserver))
 		{
-			$NicInformation += @{ Data = "Primary Server"; Value = $Nic.winsprimaryserver; }
+			$NicInformation.Add(@{ Data = "Primary Server"; Value = $Nic.winsprimaryserver; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winssecondaryserver))
 		{
-			$NicInformation += @{ Data = "Secondary Server"; Value = $Nic.winssecondaryserver; }
+			$NicInformation.Add(@{ Data = "Secondary Server"; Value = $Nic.winssecondaryserver; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winsscopeid))
 		{
-			$NicInformation += @{ Data = "Scope ID"; Value = $Nic.winsscopeid; }
+			$NicInformation.Add(@{ Data = "Scope ID"; Value = $Nic.winsscopeid; }) > $Null
 		}
 		$Table = AddWordTable -Hashtable $NicInformation -Columns Data,Value -List -AutoFit $wdAutoFitFixed;
 
@@ -2712,6 +2744,7 @@ Function OutputNicItem
 
 		FindWordDocumentEnd
 		$Table = $Null
+		WriteWordLine 0 0 ""
 	}
 	ElseIf($Text)
 	{
@@ -2811,6 +2844,7 @@ Function OutputNicItem
 		{
 			Line 3 "Scope ID`t`t: " $nic.winsscopeid
 		}
+		Line 0 ""
 	}
 	ElseIf($HTML)
 	{
@@ -2910,8 +2944,8 @@ Function OutputNicItem
 
 		$msg = ""
 		$columnWidths = @("150px","200px")
-		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths
+		WriteHTMLLine 0 0 ""
 	}
 }
 #endregion
@@ -3309,7 +3343,9 @@ Function CheckWordPrereq
 	$SessionID = (Get-Process -PID $PID).SessionId
 	
 	#Find out if winword is running in our session
-	[bool]$wordrunning = ((Get-Process 'WinWord' -ea 0)| Where-Object {$_.SessionId -eq $SessionID}) -ne $Null
+	#[bool]$wordrunning = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}) -ne $Null
+	#fix by MBS in V2.20
+	[bool]$wordrunning = $null –ne ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID})
 	If($wordrunning)
 	{
 		$ErrorActionPreference = $SaveEAPreference
@@ -4991,7 +5027,10 @@ Function CheckExcelPrereq
 	$SessionID = (Get-Process -PID $PID).SessionId
 	
 	#Find out if excel is running in our session
-	[bool]$excelrunning = ((Get-Process 'Excel' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}) -ne $Null
+	#[bool]$excelrunning = ((Get-Process 'Excel' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}) -ne $Null
+	#fix by MBS in V2.20
+	[bool]$excelrunning = $null –ne ((Get-Process 'Excel' -ea 0) | Where-Object {$_.SessionId -eq $SessionID})
+	
 	If($excelrunning)
 	{
 		$ErrorActionPreference = $SaveEAPreference
@@ -6964,34 +7003,37 @@ Function OutputMachineDetails
 		$ScriptInformation += @{ Data = "Name"; Value = $Machine.DNSName; }
 		$ScriptInformation += @{ Data = "Machine Catalog"; Value = $Machine.CatalogName; }
 		$ScriptInformation += @{ Data = "Delivery Group"; Value = $Machine.DesktopGroupName; }
-		$ScriptInformation += @{ Data = "User Display Name"; Value = $xAssociatedUserFullNames[0]; }
-		$cnt = -1
-		ForEach($tmp in $xAssociatedUserFullNames)
+		If($NoSessions -eq $False) #V1.44
 		{
-			$cnt++
-			If($cnt -gt 0)
+			$ScriptInformation += @{ Data = "User Display Name"; Value = $xAssociatedUserFullNames[0]; }
+			$cnt = -1
+			ForEach($tmp in $xAssociatedUserFullNames)
 			{
-				$ScriptInformation += @{ Data = ""; Value = $tmp; }
+				$cnt++
+				If($cnt -gt 0)
+				{
+					$ScriptInformation += @{ Data = ""; Value = $tmp; }
+				}
 			}
-		}
-		$ScriptInformation += @{ Data = "User"; Value = $xAssociatedUserNames[0]; }
-		$cnt = -1
-		ForEach($tmp in $xAssociatedUserNames)
-		{
-			$cnt++
-			If($cnt -gt 0)
+			$ScriptInformation += @{ Data = "User"; Value = $xAssociatedUserNames[0]; }
+			$cnt = -1
+			ForEach($tmp in $xAssociatedUserNames)
 			{
-				$ScriptInformation += @{ Data = ""; Value = $tmp; }
+				$cnt++
+				If($cnt -gt 0)
+				{
+					$ScriptInformation += @{ Data = ""; Value = $tmp; }
+				}
 			}
-		}
-		$ScriptInformation += @{ Data = "UPN"; Value = $xAssociatedUserUPNs[0]; }
-		$cnt = -1
-		ForEach($tmp in $xAssociatedUserUPNs)
-		{
-			$cnt++
-			If($cnt -gt 0)
+			$ScriptInformation += @{ Data = "UPN"; Value = $xAssociatedUserUPNs[0]; }
+			$cnt = -1
+			ForEach($tmp in $xAssociatedUserUPNs)
 			{
-				$ScriptInformation += @{ Data = ""; Value = $tmp; }
+				$cnt++
+				If($cnt -gt 0)
+				{
+					$ScriptInformation += @{ Data = ""; Value = $tmp; }
+				}
 			}
 		}
 		$ScriptInformation += @{ Data = "Desktop Conditions"; Value = $xDesktopConditions[0]; }
@@ -7104,142 +7146,145 @@ Function OutputMachineDetails
 		$Table = $Null
 		WriteWordLine 0 0 ""
 		
-		WriteWordLine 4 0 "Connection"
-		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{ Data = "Client (IP)"; Value = $Machine.SessionClientAddress; }
-		$ScriptInformation += @{ Data = "Client"; Value = $Machine.SessionClientName; }
-		$ScriptInformation += @{ Data = "Plug-in Version"; Value = $Machine.SessionClientVersion; }
-		$ScriptInformation += @{ Data = "Connected Via"; Value = $Machine.SessionConnectedViaHostName; }
-		$ScriptInformation += @{ Data = "Connected Via (IP)"; Value = $Machine.SessionConnectedViaIP; }
-		$ScriptInformation += @{ Data = "Last Connection Time"; Value = $Machine.LastConnectionTime ; }
-		$ScriptInformation += @{ Data = "Last Connection User"; Value = $Machine.LastConnectionUser; }
-		$ScriptInformation += @{ Data = "Connection Type"; Value = $Machine.SessionProtocol; }
-		$ScriptInformation += @{ Data = "Secure ICA Active"; Value = $xSessionSecureIcaActive ; }
-
-		$Table = AddWordTable -Hashtable $ScriptInformation `
-		-Columns Data,Value `
-		-List `
-		-Format $wdTableGrid `
-		-AutoFit $wdAutoFitFixed;
-
-		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
-
-		$Table.Columns.Item(1).Width = 200;
-		$Table.Columns.Item(2).Width = 250;
-
-		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
-
-		FindWordDocumentEnd
-		$Table = $Null
-		WriteWordLine 0 0 ""
-		
-		WriteWordLine 4 0 "Registration"
-		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{ Data = "Broker"; Value = $Machine.ControllerDNSName; }
-		$ScriptInformation += @{ Data = "Last registration failure"; Value = $xLastDeregistrationReason; }
-		$ScriptInformation += @{ Data = "Last registration failure time"; Value = $Machine.LastDeregistrationTime; }
-		$ScriptInformation += @{ Data = "Registration State"; Value = $Machine.RegistrationState; }
-
-		$Table = AddWordTable -Hashtable $ScriptInformation `
-		-Columns Data,Value `
-		-List `
-		-Format $wdTableGrid `
-		-AutoFit $wdAutoFitFixed;
-
-		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
-
-		$Table.Columns.Item(1).Width = 200;
-		$Table.Columns.Item(2).Width = 250;
-
-		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
-
-		FindWordDocumentEnd
-		$Table = $Null
-		WriteWordLine 0 0 ""
-		
-		WriteWordLine 4 0 "Hosting"
-		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{ Data = "VM"; Value = $Machine.HostedMachineName; }
-		$ScriptInformation += @{ Data = "Hosting Server Name"; Value = $Machine.HostingServerName; }
-		$ScriptInformation += @{ Data = "Connection"; Value = $Machine.HypervisorConnectionName ; }
-		$ScriptInformation += @{ Data = "Pending Update"; Value = $Machine.ImageOutOfDate; }
-		$ScriptInformation += @{ Data = "Persist User Changes"; Value = $xPersistUserChanges; }
-		$ScriptInformation += @{ Data = "Power Action Pending"; Value = $Machine.PowerActionPending; }
-		$ScriptInformation += @{ Data = "Power State"; Value = $Machine.PowerState; }
-		$ScriptInformation += @{ Data = "Will Shutdown After Use"; Value = $xWillShutdownAfterUse; }
-
-		$Table = AddWordTable -Hashtable $ScriptInformation `
-		-Columns Data,Value `
-		-List `
-		-Format $wdTableGrid `
-		-AutoFit $wdAutoFitFixed;
-
-		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
-
-		$Table.Columns.Item(1).Width = 200;
-		$Table.Columns.Item(2).Width = 250;
-
-		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
-
-		FindWordDocumentEnd
-		$Table = $Null
-		WriteWordLine 0 0 ""
-		
-		WriteWordLine 4 0 "Session Details"
-		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{ Data = "Launched Via"; Value = $Machine.SessionLaunchedViaHostName; }
-		$ScriptInformation += @{ Data = "Launched Via (IP)"; Value = $Machine.SessionLaunchedViaIP; }
-		$ScriptInformation += @{ Data = "Session Change Time"; Value = $Machine.SessionStateChangeTime; }
-		$ScriptInformation += @{ Data = "SmartAccess Filters"; Value = $xSessionSmartAccessTags[0]; }
-		$cnt = -1
-		ForEach($tmp in $xSessionSmartAccessTags)
+		If($NoSessions -eq $False) #V1.44
 		{
-			$cnt++
-			If($cnt -gt 0)
+			WriteWordLine 4 0 "Connection"
+			[System.Collections.Hashtable[]] $ScriptInformation = @()
+			$ScriptInformation += @{ Data = "Client (IP)"; Value = $Machine.SessionClientAddress; }
+			$ScriptInformation += @{ Data = "Client"; Value = $Machine.SessionClientName; }
+			$ScriptInformation += @{ Data = "Plug-in Version"; Value = $Machine.SessionClientVersion; }
+			$ScriptInformation += @{ Data = "Connected Via"; Value = $Machine.SessionConnectedViaHostName; }
+			$ScriptInformation += @{ Data = "Connected Via (IP)"; Value = $Machine.SessionConnectedViaIP; }
+			$ScriptInformation += @{ Data = "Last Connection Time"; Value = $Machine.LastConnectionTime ; }
+			$ScriptInformation += @{ Data = "Last Connection User"; Value = $Machine.LastConnectionUser; }
+			$ScriptInformation += @{ Data = "Connection Type"; Value = $Machine.SessionProtocol; }
+			$ScriptInformation += @{ Data = "Secure ICA Active"; Value = $xSessionSecureIcaActive ; }
+
+			$Table = AddWordTable -Hashtable $ScriptInformation `
+			-Columns Data,Value `
+			-List `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+			$Table.Columns.Item(1).Width = 200;
+			$Table.Columns.Item(2).Width = 250;
+
+			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
+
+			FindWordDocumentEnd
+			$Table = $Null
+			WriteWordLine 0 0 ""
+			
+			WriteWordLine 4 0 "Registration"
+			[System.Collections.Hashtable[]] $ScriptInformation = @()
+			$ScriptInformation += @{ Data = "Broker"; Value = $Machine.ControllerDNSName; }
+			$ScriptInformation += @{ Data = "Last registration failure"; Value = $xLastDeregistrationReason; }
+			$ScriptInformation += @{ Data = "Last registration failure time"; Value = $Machine.LastDeregistrationTime; }
+			$ScriptInformation += @{ Data = "Registration State"; Value = $Machine.RegistrationState; }
+
+			$Table = AddWordTable -Hashtable $ScriptInformation `
+			-Columns Data,Value `
+			-List `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+			$Table.Columns.Item(1).Width = 200;
+			$Table.Columns.Item(2).Width = 250;
+
+			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
+
+			FindWordDocumentEnd
+			$Table = $Null
+			WriteWordLine 0 0 ""
+			
+			WriteWordLine 4 0 "Hosting"
+			[System.Collections.Hashtable[]] $ScriptInformation = @()
+			$ScriptInformation += @{ Data = "VM"; Value = $Machine.HostedMachineName; }
+			$ScriptInformation += @{ Data = "Hosting Server Name"; Value = $Machine.HostingServerName; }
+			$ScriptInformation += @{ Data = "Connection"; Value = $Machine.HypervisorConnectionName ; }
+			$ScriptInformation += @{ Data = "Pending Update"; Value = $Machine.ImageOutOfDate; }
+			$ScriptInformation += @{ Data = "Persist User Changes"; Value = $xPersistUserChanges; }
+			$ScriptInformation += @{ Data = "Power Action Pending"; Value = $Machine.PowerActionPending; }
+			$ScriptInformation += @{ Data = "Power State"; Value = $Machine.PowerState; }
+			$ScriptInformation += @{ Data = "Will Shutdown After Use"; Value = $xWillShutdownAfterUse; }
+
+			$Table = AddWordTable -Hashtable $ScriptInformation `
+			-Columns Data,Value `
+			-List `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+			$Table.Columns.Item(1).Width = 200;
+			$Table.Columns.Item(2).Width = 250;
+
+			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
+
+			FindWordDocumentEnd
+			$Table = $Null
+			WriteWordLine 0 0 ""
+			
+			WriteWordLine 4 0 "Session Details"
+			[System.Collections.Hashtable[]] $ScriptInformation = @()
+			$ScriptInformation += @{ Data = "Launched Via"; Value = $Machine.SessionLaunchedViaHostName; }
+			$ScriptInformation += @{ Data = "Launched Via (IP)"; Value = $Machine.SessionLaunchedViaIP; }
+			$ScriptInformation += @{ Data = "Session Change Time"; Value = $Machine.SessionStateChangeTime; }
+			$ScriptInformation += @{ Data = "SmartAccess Filters"; Value = $xSessionSmartAccessTags[0]; }
+			$cnt = -1
+			ForEach($tmp in $xSessionSmartAccessTags)
 			{
-				$ScriptInformation += @{ Data = ""; Value = $tmp; }
+				$cnt++
+				If($cnt -gt 0)
+				{
+					$ScriptInformation += @{ Data = ""; Value = $tmp; }
+				}
 			}
+
+			$Table = AddWordTable -Hashtable $ScriptInformation `
+			-Columns Data,Value `
+			-List `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+			$Table.Columns.Item(1).Width = 200;
+			$Table.Columns.Item(2).Width = 250;
+
+			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
+
+			FindWordDocumentEnd
+			$Table = $Null
+			WriteWordLine 0 0 ""
+			
+			WriteWordLine 4 0 "Session"
+			[System.Collections.Hashtable[]] $ScriptInformation = @()
+			$ScriptInformation += @{ Data = "Session State"; Value = $Machine.SessionState; }
+			$ScriptInformation += @{ Data = "Current User"; Value = $Machine.SessionUserName; }
+			$ScriptInformation += @{ Data = "Start Time"; Value = $Machine.SessionStateChangeTIme; }
+
+			$Table = AddWordTable -Hashtable $ScriptInformation `
+			-Columns Data,Value `
+			-List `
+			-Format $wdTableGrid `
+			-AutoFit $wdAutoFitFixed;
+
+			SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+
+			$Table.Columns.Item(1).Width = 200;
+			$Table.Columns.Item(2).Width = 250;
+
+			$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
+
+			FindWordDocumentEnd
+			$Table = $Null
+			WriteWordLine 0 0 ""
 		}
-
-		$Table = AddWordTable -Hashtable $ScriptInformation `
-		-Columns Data,Value `
-		-List `
-		-Format $wdTableGrid `
-		-AutoFit $wdAutoFitFixed;
-
-		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
-
-		$Table.Columns.Item(1).Width = 200;
-		$Table.Columns.Item(2).Width = 250;
-
-		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
-
-		FindWordDocumentEnd
-		$Table = $Null
-		WriteWordLine 0 0 ""
-		
-		WriteWordLine 4 0 "Session"
-		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{ Data = "Session State"; Value = $Machine.SessionState; }
-		$ScriptInformation += @{ Data = "Current User"; Value = $Machine.SessionUserName; }
-		$ScriptInformation += @{ Data = "Start Time"; Value = $Machine.SessionStateChangeTIme; }
-
-		$Table = AddWordTable -Hashtable $ScriptInformation `
-		-Columns Data,Value `
-		-List `
-		-Format $wdTableGrid `
-		-AutoFit $wdAutoFitFixed;
-
-		SetWordCellFormat -Collection $Table.Columns.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
-
-		$Table.Columns.Item(1).Width = 200;
-		$Table.Columns.Item(2).Width = 250;
-
-		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
-
-		FindWordDocumentEnd
-		$Table = $Null
-		WriteWordLine 0 0 ""
 	}
 	ElseIf($Text)
 	{
@@ -7247,34 +7292,37 @@ Function OutputMachineDetails
 		Line 2 "Name`t`t`t`t: " $Machine.DNSName
 		Line 2 "Machine Catalog`t`t`t: " $Machine.CatalogName
 		Line 2 "Delivery Group`t`t`t: " $Machine.DesktopGroupName
-		Line 2 "User Display Name`t`t: " $xAssociatedUserFullNames[0]
-		$cnt = -1
-		ForEach($tmp in $xAssociatedUserFullNames)
+		If($NoSessions -eq $False) #V1.44
 		{
-			$cnt++
-			If($cnt -gt 0)
+			Line 2 "User Display Name`t`t: " $xAssociatedUserFullNames[0]
+			$cnt = -1
+			ForEach($tmp in $xAssociatedUserFullNames)
 			{
-				Line 6 "  " $tmp
+				$cnt++
+				If($cnt -gt 0)
+				{
+					Line 6 "  " $tmp
+				}
 			}
-		}
-		Line 2 "User`t`t`t`t: " $xAssociatedUserNames[0]
-		$cnt = -1
-		ForEach($tmp in $xAssociatedUserNames)
-		{
-			$cnt++
-			If($cnt -gt 0)
+			Line 2 "User`t`t`t`t: " $xAssociatedUserNames[0]
+			$cnt = -1
+			ForEach($tmp in $xAssociatedUserNames)
 			{
-				Line 6 "  " $tmp
+				$cnt++
+				If($cnt -gt 0)
+				{
+					Line 6 "  " $tmp
+				}
 			}
-		}
-		Line 2 "UPN`t`t`t`t: " $xAssociatedUserUPNs[0]
-		$cnt = -1
-		ForEach($tmp in $xAssociatedUserUPNs)
-		{
-			$cnt++
-			If($cnt -gt 0)
+			Line 2 "UPN`t`t`t`t: " $xAssociatedUserUPNs[0]
+			$cnt = -1
+			ForEach($tmp in $xAssociatedUserUPNs)
 			{
-				Line 6 "  " $tmp
+				$cnt++
+				If($cnt -gt 0)
+				{
+					Line 6 "  " $tmp
+				}
 			}
 		}
 		Line 2 "Desktop Conditions`t`t: " $xDesktopConditions[0]
@@ -7336,57 +7384,60 @@ Function OutputMachineDetails
 		}
 		Line 0 ""
 		
-		Line 1 "Connection"
-		Line 2 "Client (IP)`t`t`t: " $Machine.SessionClientAddress
-		Line 2 "Client`t`t`t`t: " $Machine.SessionClientName
-		Line 2 "Plug-in Version`t`t`t: " $Machine.SessionClientVersion
-		Line 2 "Connected Via`t`t`t: " $Machine.SessionConnectedViaHostName
-		Line 2 "Connect Via (IP)`t`t: " $Machine.SessionConnectedViaIP
-		Line 2 "Last Connection Time`t`t: " $Machine.LastConnectionTime 
-		Line 2 "Last Connection User`t`t: " $Machine.LastConnectionUser
-		Line 2 "Connection Type`t`t`t: " $Machine.SessionProtocol
-		Line 2 "Secure ICA Active`t`t: " $xSessionSecureIcaActive 
-		Line 0 ""
-		
-		Line 1 "Registration"
-		Line 2 "Broker`t`t`t`t: " $Machine.ControllerDNSName
-		Line 2 "Last registration failure`t: " $xLastDeregistrationReason
-		Line 2 "Last registration failure time`t: " $Machine.LastDeregistrationTime
-		Line 2 "Registration State`t`t: " $Machine.RegistrationState
-		Line 0 ""
-		
-		Line 1 "Hosting"
-		Line 2 "VM`t`t`t`t: " $Machine.HostedMachineName
-		Line 2 "Hosting Server Name`t`t: " $Machine.HostingServerName
-		Line 2 "Connection`t`t`t: " $Machine.HypervisorConnectionName 
-		Line 2 "Pending Update`t`t`t: " $Machine.ImageOutOfDate
-		Line 2 "Persist User Changes`t`t: " $xPersistUserChanges
-		Line 2 "Power Action Pending`t`t: " $Machine.PowerActionPending
-		Line 2 "Power State`t`t`t: " $Machine.PowerState
-		Line 2 "Will Shutdown After Use`t`t: " $xWillShutdownAfterUse
-		Line 0 ""
-		
-		Line 1 "Session Details"
-		Line 2 "Launched Via`t`t`t: " $Machine.SessionLaunchedViaHostName
-		Line 2 "Launched Via (IP)`t`t: " $Machine.SessionLaunchedViaIP
-		Line 2 "Session Change Time`t`t: " $Machine.SessionStateChangeTime
-		Line 2 "SmartAccess Filters`t`t: " $xSessionSmartAccessTags[0]
-		$cnt = -1
-		ForEach($tmp in $xSessionSmartAccessTags)
+		If($NoSessions -eq $False) #V1.44
 		{
-			$cnt++
-			If($cnt -gt 0)
+			Line 1 "Connection"
+			Line 2 "Client (IP)`t`t`t: " $Machine.SessionClientAddress
+			Line 2 "Client`t`t`t`t: " $Machine.SessionClientName
+			Line 2 "Plug-in Version`t`t`t: " $Machine.SessionClientVersion
+			Line 2 "Connected Via`t`t`t: " $Machine.SessionConnectedViaHostName
+			Line 2 "Connect Via (IP)`t`t: " $Machine.SessionConnectedViaIP
+			Line 2 "Last Connection Time`t`t: " $Machine.LastConnectionTime 
+			Line 2 "Last Connection User`t`t: " $Machine.LastConnectionUser
+			Line 2 "Connection Type`t`t`t: " $Machine.SessionProtocol
+			Line 2 "Secure ICA Active`t`t: " $xSessionSecureIcaActive 
+			Line 0 ""
+			
+			Line 1 "Registration"
+			Line 2 "Broker`t`t`t`t: " $Machine.ControllerDNSName
+			Line 2 "Last registration failure`t: " $xLastDeregistrationReason
+			Line 2 "Last registration failure time`t: " $Machine.LastDeregistrationTime
+			Line 2 "Registration State`t`t: " $Machine.RegistrationState
+			Line 0 ""
+			
+			Line 1 "Hosting"
+			Line 2 "VM`t`t`t`t: " $Machine.HostedMachineName
+			Line 2 "Hosting Server Name`t`t: " $Machine.HostingServerName
+			Line 2 "Connection`t`t`t: " $Machine.HypervisorConnectionName 
+			Line 2 "Pending Update`t`t`t: " $Machine.ImageOutOfDate
+			Line 2 "Persist User Changes`t`t: " $xPersistUserChanges
+			Line 2 "Power Action Pending`t`t: " $Machine.PowerActionPending
+			Line 2 "Power State`t`t`t: " $Machine.PowerState
+			Line 2 "Will Shutdown After Use`t`t: " $xWillShutdownAfterUse
+			Line 0 ""
+			
+			Line 1 "Session Details"
+			Line 2 "Launched Via`t`t`t: " $Machine.SessionLaunchedViaHostName
+			Line 2 "Launched Via (IP)`t`t: " $Machine.SessionLaunchedViaIP
+			Line 2 "Session Change Time`t`t: " $Machine.SessionStateChangeTime
+			Line 2 "SmartAccess Filters`t`t: " $xSessionSmartAccessTags[0]
+			$cnt = -1
+			ForEach($tmp in $xSessionSmartAccessTags)
 			{
-				Line 5 "  " $tmp
+				$cnt++
+				If($cnt -gt 0)
+				{
+					Line 5 "  " $tmp
+				}
 			}
+			Line 0 ""
+			
+			Line 1 "Session"
+			Line 2 "Session State`t`t`t: " $Machine.SessionState
+			Line 2 "Current User`t`t`t: " $Machine.SessionUserName
+			Line 2 "Start Time`t`t`t: " $Machine.SessionUserName
+			Line 0 ""
 		}
-		Line 0 ""
-		
-		Line 1 "Session"
-		Line 2 "Session State`t`t`t: " $Machine.SessionState
-		Line 2 "Current User`t`t`t: " $Machine.SessionUserName
-		Line 2 "Start Time`t`t`t: " $Machine.SessionUserName
-		Line 0 ""
 	}
 	ElseIf($HTML)
 	{
@@ -7396,34 +7447,37 @@ Function OutputMachineDetails
 		$columnHeaders = @("Name",($htmlsilver -bor $htmlbold),$Machine.DNSName,$htmlwhite)
 		$rowdata += @(,('Machine Catalog',($htmlsilver -bor $htmlbold),$Machine.CatalogName,$htmlwhite))
 		$rowdata += @(,('Delivery Group',($htmlsilver -bor $htmlbold),$Machine.DesktopGroupName,$htmlwhite))
-		$rowdata += @(,('User Display Name',($htmlsilver -bor $htmlbold),$xAssociatedUserFullNames[0],$htmlwhite))
-		$cnt = -1
-		ForEach($tmp in $xAssociatedUserFullNames)
+		If($NoSessions -eq $False) #V1.44
 		{
-			$cnt++
-			If($cnt -gt 0)
+			$rowdata += @(,('User Display Name',($htmlsilver -bor $htmlbold),$xAssociatedUserFullNames[0],$htmlwhite))
+			$cnt = -1
+			ForEach($tmp in $xAssociatedUserFullNames)
 			{
-				$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				$cnt++
+				If($cnt -gt 0)
+				{
+					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				}
 			}
-		}
-		$rowdata += @(,('User',($htmlsilver -bor $htmlbold),$xAssociatedUserNames[0],$htmlwhite))
-		$cnt = -1
-		ForEach($tmp in $xAssociatedUserNames)
-		{
-			$cnt++
-			If($cnt -gt 0)
+			$rowdata += @(,('User',($htmlsilver -bor $htmlbold),$xAssociatedUserNames[0],$htmlwhite))
+			$cnt = -1
+			ForEach($tmp in $xAssociatedUserNames)
 			{
-				$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				$cnt++
+				If($cnt -gt 0)
+				{
+					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				}
 			}
-		}
-		$rowdata += @(,('UPN',($htmlsilver -bor $htmlbold),$xAssociatedUserUPNs[0],$htmlwhite))
-		$cnt = -1
-		ForEach($tmp in $xAssociatedUserUPNs)
-		{
-			$cnt++
-			If($cnt -gt 0)
+			$rowdata += @(,('UPN',($htmlsilver -bor $htmlbold),$xAssociatedUserUPNs[0],$htmlwhite))
+			$cnt = -1
+			ForEach($tmp in $xAssociatedUserUPNs)
 			{
-				$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				$cnt++
+				If($cnt -gt 0)
+				{
+					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				}
 			}
 		}
 		$rowdata += @(,('Desktop Conditions',($htmlsilver -bor $htmlbold),$xDesktopConditions[0],$htmlwhite))
@@ -7499,82 +7553,85 @@ Function OutputMachineDetails
 		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
 		WriteHTMLLine 0 0 " "
 
-		WriteHTMLLine 4 0 "Connection"
-		$rowdata = @()
-		$columnHeaders = @("Client (IP)",($htmlsilver -bor $htmlbold),$Machine.SessionClientAddress,$htmlwhite)
-		$rowdata += @(,('Client',($htmlsilver -bor $htmlbold),$Machine.SessionClientName,$htmlwhite))
-		$rowdata += @(,('Plug-in Version',($htmlsilver -bor $htmlbold),$Machine.SessionClientVersion,$htmlwhite))
-		$rowdata += @(,('Connected Via',($htmlsilver -bor $htmlbold),$Machine.SessionConnectedViaHostName,$htmlwhite))
-		$rowdata += @(,('Connect Via (IP)',($htmlsilver -bor $htmlbold),$Machine.SessionConnectedViaIP,$htmlwhite))
-		$rowdata += @(,('Last Connection Time',($htmlsilver -bor $htmlbold),$Machine.LastConnectionTime,$htmlwhite))
-		$rowdata += @(,('Last Connection User',($htmlsilver -bor $htmlbold),$Machine.LastConnectionUser,$htmlwhite))
-		$rowdata += @(,('Connection Type',($htmlsilver -bor $htmlbold),$Machine.SessionProtocol,$htmlwhite))
-		$rowdata += @(,('Secure ICA Active',($htmlsilver -bor $htmlbold),$xSessionSecureIcaActive,$htmlwhite))
-
-		$msg = ""
-		$columnWidths = @("200px","250px")
-		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
-		WriteHTMLLine 0 0 " "
-
-		WriteHTMLLine 4 0 "Registration"
-		$rowdata = @()
-		$columnHeaders = @("Broker",($htmlsilver -bor $htmlbold),$Machine.ControllerDNSName,$htmlwhite)
-		$rowdata += @(,('Last registration failure',($htmlsilver -bor $htmlbold),$xLastDeregistrationReason,$htmlwhite))
-		$rowdata += @(,('Last registration failure time',($htmlsilver -bor $htmlbold),$Machine.LastDeregistrationTime,$htmlwhite))
-		$rowdata += @(,('Registration State',($htmlsilver -bor $htmlbold),$Machine.RegistrationState,$htmlwhite))
-
-		$msg = ""
-		$columnWidths = @("200px","250px")
-		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
-		WriteHTMLLine 0 0 " "
-
-		WriteHTMLLine 4 0 "Hosting"
-		$rowdata = @()
-		$columnHeaders = @("VM",($htmlsilver -bor $htmlbold),$Machine.HostedMachineName,$htmlwhite)
-		$rowdata += @(,('Hosting Server Name',($htmlsilver -bor $htmlbold),$Machine.HostingServerName,$htmlwhite))
-		$rowdata += @(,('Connection',($htmlsilver -bor $htmlbold),$Machine.HypervisorConnectionName,$htmlwhite))
-		$rowdata += @(,('Pending Update',($htmlsilver -bor $htmlbold),$Machine.ImageOutOfDate,$htmlwhite))
-		$rowdata += @(,('Persist User Changes',($htmlsilver -bor $htmlbold),$xPersistUserChanges,$htmlwhite))
-		$rowdata += @(,('Power Action Pending',($htmlsilver -bor $htmlbold),$Machine.PowerActionPending,$htmlwhite))
-		$rowdata += @(,('Power State',($htmlsilver -bor $htmlbold),$Machine.PowerState,$htmlwhite))
-		$rowdata += @(,('Will Shutdown After Use',($htmlsilver -bor $htmlbold),$xWillShutdownAfterUse,$htmlwhite))
-
-		$msg = ""
-		$columnWidths = @("200px","250px")
-		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
-		WriteHTMLLine 0 0 " "
-
-		WriteHTMLLine 4 0 "Session Details"
-		$rowdata = @()
-		$columnHeaders = @("Launched Via",($htmlsilver -bor $htmlbold),$Machine.SessionLaunchedViaHostName,$htmlwhite)
-		$rowdata += @(,('Launched Via (IP)',($htmlsilver -bor $htmlbold),$Machine.SessionLaunchedViaIP,$htmlwhite))
-		$rowdata += @(,('Session Change Time',($htmlsilver -bor $htmlbold),$Machine.SessionStateChangeTime,$htmlwhite))
-		$rowdata += @(,('SmartAccess Filters',($htmlsilver -bor $htmlbold),$xSessionSmartAccessTags[0],$htmlwhite))
-		$cnt = -1
-		ForEach($tmp in $xSessionSmartAccessTags)
+		If($NoSessions -eq $False) #V1.44
 		{
-			$cnt++
-			If($cnt -gt 0)
+			WriteHTMLLine 4 0 "Connection"
+			$rowdata = @()
+			$columnHeaders = @("Client (IP)",($htmlsilver -bor $htmlbold),$Machine.SessionClientAddress,$htmlwhite)
+			$rowdata += @(,('Client',($htmlsilver -bor $htmlbold),$Machine.SessionClientName,$htmlwhite))
+			$rowdata += @(,('Plug-in Version',($htmlsilver -bor $htmlbold),$Machine.SessionClientVersion,$htmlwhite))
+			$rowdata += @(,('Connected Via',($htmlsilver -bor $htmlbold),$Machine.SessionConnectedViaHostName,$htmlwhite))
+			$rowdata += @(,('Connect Via (IP)',($htmlsilver -bor $htmlbold),$Machine.SessionConnectedViaIP,$htmlwhite))
+			$rowdata += @(,('Last Connection Time',($htmlsilver -bor $htmlbold),$Machine.LastConnectionTime,$htmlwhite))
+			$rowdata += @(,('Last Connection User',($htmlsilver -bor $htmlbold),$Machine.LastConnectionUser,$htmlwhite))
+			$rowdata += @(,('Connection Type',($htmlsilver -bor $htmlbold),$Machine.SessionProtocol,$htmlwhite))
+			$rowdata += @(,('Secure ICA Active',($htmlsilver -bor $htmlbold),$xSessionSecureIcaActive,$htmlwhite))
+
+			$msg = ""
+			$columnWidths = @("200px","250px")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
+			WriteHTMLLine 0 0 " "
+
+			WriteHTMLLine 4 0 "Registration"
+			$rowdata = @()
+			$columnHeaders = @("Broker",($htmlsilver -bor $htmlbold),$Machine.ControllerDNSName,$htmlwhite)
+			$rowdata += @(,('Last registration failure',($htmlsilver -bor $htmlbold),$xLastDeregistrationReason,$htmlwhite))
+			$rowdata += @(,('Last registration failure time',($htmlsilver -bor $htmlbold),$Machine.LastDeregistrationTime,$htmlwhite))
+			$rowdata += @(,('Registration State',($htmlsilver -bor $htmlbold),$Machine.RegistrationState,$htmlwhite))
+
+			$msg = ""
+			$columnWidths = @("200px","250px")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
+			WriteHTMLLine 0 0 " "
+
+			WriteHTMLLine 4 0 "Hosting"
+			$rowdata = @()
+			$columnHeaders = @("VM",($htmlsilver -bor $htmlbold),$Machine.HostedMachineName,$htmlwhite)
+			$rowdata += @(,('Hosting Server Name',($htmlsilver -bor $htmlbold),$Machine.HostingServerName,$htmlwhite))
+			$rowdata += @(,('Connection',($htmlsilver -bor $htmlbold),$Machine.HypervisorConnectionName,$htmlwhite))
+			$rowdata += @(,('Pending Update',($htmlsilver -bor $htmlbold),$Machine.ImageOutOfDate,$htmlwhite))
+			$rowdata += @(,('Persist User Changes',($htmlsilver -bor $htmlbold),$xPersistUserChanges,$htmlwhite))
+			$rowdata += @(,('Power Action Pending',($htmlsilver -bor $htmlbold),$Machine.PowerActionPending,$htmlwhite))
+			$rowdata += @(,('Power State',($htmlsilver -bor $htmlbold),$Machine.PowerState,$htmlwhite))
+			$rowdata += @(,('Will Shutdown After Use',($htmlsilver -bor $htmlbold),$xWillShutdownAfterUse,$htmlwhite))
+
+			$msg = ""
+			$columnWidths = @("200px","250px")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
+			WriteHTMLLine 0 0 " "
+
+			WriteHTMLLine 4 0 "Session Details"
+			$rowdata = @()
+			$columnHeaders = @("Launched Via",($htmlsilver -bor $htmlbold),$Machine.SessionLaunchedViaHostName,$htmlwhite)
+			$rowdata += @(,('Launched Via (IP)',($htmlsilver -bor $htmlbold),$Machine.SessionLaunchedViaIP,$htmlwhite))
+			$rowdata += @(,('Session Change Time',($htmlsilver -bor $htmlbold),$Machine.SessionStateChangeTime,$htmlwhite))
+			$rowdata += @(,('SmartAccess Filters',($htmlsilver -bor $htmlbold),$xSessionSmartAccessTags[0],$htmlwhite))
+			$cnt = -1
+			ForEach($tmp in $xSessionSmartAccessTags)
 			{
-				$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				$cnt++
+				If($cnt -gt 0)
+				{
+					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				}
 			}
+
+			$msg = ""
+			$columnWidths = @("200px","250px")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
+			WriteHTMLLine 0 0 " "
+
+			WriteHTMLLine 4 0 "Session"
+			$rowdata = @()
+			$columnHeaders = @("Session State",($htmlsilver -bor $htmlbold),$Machine.SessionState,$htmlwhite)
+			$rowdata += @(,('Current User',($htmlsilver -bor $htmlbold),$Machine.SessionUserName,$htmlwhite))
+			$rowdata += @(,('Start Time',($htmlsilver -bor $htmlbold),$Machine.SessionUserName,$htmlwhite))
+
+			$msg = ""
+			$columnWidths = @("200px","250px")
+			FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
+			WriteHTMLLine 0 0 " "
 		}
-
-		$msg = ""
-		$columnWidths = @("200px","250px")
-		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
-		WriteHTMLLine 0 0 " "
-
-		WriteHTMLLine 4 0 "Session"
-		$rowdata = @()
-		$columnHeaders = @("Session State",($htmlsilver -bor $htmlbold),$Machine.SessionState,$htmlwhite)
-		$rowdata += @(,('Current User',($htmlsilver -bor $htmlbold),$Machine.SessionUserName,$htmlwhite))
-		$rowdata += @(,('Start Time',($htmlsilver -bor $htmlbold),$Machine.SessionUserName,$htmlwhite))
-
-		$msg = ""
-		$columnWidths = @("200px","250px")
-		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "450"
-		WriteHTMLLine 0 0 " "
 	}
 }
 
@@ -7939,6 +7996,7 @@ Function OutputServerMachineDetails
 		$ScriptInformation += @{ Data = "Persist User Changes"; Value = $xPersistUserChanges; }
 		$ScriptInformation += @{ Data = "Power Action Pending"; Value = $Machine.PowerActionPending; }
 		$ScriptInformation += @{ Data = "Power State"; Value = $Machine.PowerState; }
+		$ScriptInformation += @{Data = "Will Shutdown After Use"; Value = $xWillShutdownAfterUse; }
 
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
@@ -8144,6 +8202,7 @@ Function OutputServerMachineDetails
 		Line 2 "Persist User Changes`t`t: " $xPersistUserChanges
 		Line 2 "Power Action Pending`t`t: " $Machine.PowerActionPending
 		Line 2 "Power State`t`t`t: " $Machine.PowerState
+		Line 2 "Will Shutdown After Use`t`t: " $xWillShutdownAfterUse
 		Line 0 ""
 		
 		Line 1 "Connection"
@@ -8304,6 +8363,7 @@ Function OutputServerMachineDetails
 		$rowdata += @(,('Persist User Changes',($htmlsilver -bor $htmlbold),$xPersistUserChanges,$htmlwhite))
 		$rowdata += @(,('Power Action Pending',($htmlsilver -bor $htmlbold),$Machine.PowerActionPending,$htmlwhite))
 		$rowdata += @(,('Power State',($htmlsilver -bor $htmlbold),$Machine.PowerState,$htmlwhite))
+		$rowdata += @(,('Will Shutdown After Use',($htmlsilver -bor $htmlbold),$xWillShutdownAfterUse,$htmlwhite))
 
 		$msg = ""
 		$columnWidths = @("200px","250px")
@@ -8764,13 +8824,13 @@ Function OutputDeliveryGroupUtilization
 			$xColorDepth = "24bit - True color"
 		}
 
-		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{ Data = "Description"; Value = $Group.Description; }
-		$ScriptInformation += @{ Data = "User Icon Name"; Value = $Group.PublishedName; }
-		$ScriptInformation += @{ Data = "Desktop Type"; Value = $Group.DesktopKind; }
-		$ScriptInformation += @{ Data = "Status"; Value = $xEnabled; }
-		$ScriptInformation += @{ Data = "Automatic reboots when user logs off"; Value = $Group.ShutdownDesktopsAfterUse; }
-		$ScriptInformation += @{ Data = "Color Depth"; Value = $xColorDepth; }
+		$ScriptInformation = New-Object System.Collections.ArrayList
+		$ScriptInformation.Add(@{Data = "Description"; Value = $Group.Description; }) > $Null
+		$ScriptInformation.Add(@{Data = "User Icon Name"; Value = $Group.PublishedName; }) > $Null
+		$ScriptInformation.Add(@{Data = "Desktop Type"; Value = $Group.DesktopKind; }) > $Null
+		$ScriptInformation.Add(@{Data = "Status"; Value = $xEnabled; }) > $Null
+		$ScriptInformation.Add(@{Data = "Automatic reboots when user logs off"; Value = $Group.ShutdownDesktopsAfterUse; }) > $Null
+		$ScriptInformation.Add(@{Data = "Color Depth"; Value = $xColorDepth; }) > $Null
 
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
@@ -8823,8 +8883,8 @@ Function OutputDeliveryGroupUtilization
 			#Assumes that date is always on A column 
 			$range = $worksheet.Range("A2")
 			$selectionXL = $worksheet.Range($range,$range.end($xlDirection::xlDown))
-			$Start = @($selectionXL)[0].Text
-			$End = @($selectionXL)[-1].Text
+			#$Start = @($selectionXL)[0].Text
+			#$End = @($selectionXL)[-1].Text
 
 			Write-Verbose "$(Get-Date): `t`t`tCreating chart for $($Group.Name)"
 			$chart = $worksheet.Shapes.AddChart().Chart 
@@ -8853,8 +8913,7 @@ Function OutputDeliveryGroupUtilization
 			$word.Selection.PasteAndFormat(13)  #Pastes an Excel chart as a picture
 
 			Write-Verbose "$(Get-Date): `t`t`tClosing excel for $($Group.Name)"
-			#$excel.Workbooks.Close($false)
-			$excel.Workbooks.Close()
+			$excel.Workbooks.Close($false)
 			$excel.Quit()
 
 			FindWordDocumentEnd
@@ -8862,7 +8921,7 @@ Function OutputDeliveryGroupUtilization
 			
 			While( [System.Runtime.Interopservices.Marshal]::ReleaseComObject($selectionXL)){}
 			While( [System.Runtime.Interopservices.Marshal]::ReleaseComObject($Range)){}
-			#While( [System.Runtime.Interopservices.Marshal]::ReleaseComObject($Chart)){}
+			While( [System.Runtime.Interopservices.Marshal]::ReleaseComObject($Chart)){}
 			While( [System.Runtime.Interopservices.Marshal]::ReleaseComObject($Worksheet)){}
 			While( [System.Runtime.Interopservices.Marshal]::ReleaseComObject($Excel)){}
 
@@ -8875,32 +8934,8 @@ Function OutputDeliveryGroupUtilization
 			$SessionID = (Get-Process -PID $PID).SessionId
 			(Get-Process 'Excel' -ea 0 | Where-Object {$_.sessionid -eq $Sessionid}) | Stop-Process 4>$Null
 			
-			Write-Verbose "$(Get-Date): `t`t`tDeleting temp file $($TempFile)"
+			Write-Verbose "$(Get-Date): `t`t`tDeleting temp files $($TempFile)"
 			Remove-Item $TempFile *>$Null
-			[int]$cnt = 0
-			While(Test-Path $TempFile)
-			{
-				$cnt++
-				If($cnt -gt 1)
-				{
-					Write-Verbose "$(Get-Date): `t`t`tWaiting another 10 seconds to allow Excel to fully close (try # $($cnt))"
-					Start-Sleep -Seconds 10
-					If($cnt -gt 2)
-					{
-						#kill the winword process
-
-						#Find out if excel is running in our session
-						$excelprocess = ((Get-Process 'Excel' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}).Id
-						If($excelprocess -gt 0)
-						{
-							Write-Verbose "$(Get-Date): `t`t`tAttempting to stop Excel process # $($excelprocess)"
-							Stop-Process $excelprocess -EA 0
-						}
-					}
-				}
-				Write-Verbose "$(Get-Date): `t`t`tAttempting to delete $($TempFile) again - try # $($cnt))"
-				Remove-Item $TempFile -EA 0 4>$Null
-			}
 		}
 		ElseIf($? -and $Null -eq $Results)
 		{
@@ -8919,6 +8954,7 @@ Function OutputDeliveryGroupUtilization
 Function OutputDeliveryGroupDetails 
 {
 	Param([object] $Group)
+	#V1.44 remove unused $xDeliveryType
 
 	$xDGType = "Delivery Group Type cannot be determined: $($Group.DeliveryType) $($Group.DesktopKind)"
 	If($Group.DeliveryType -eq "AppsOnly" -and $Group.DesktopKind -eq "Shared")
@@ -8938,15 +8974,6 @@ Function OutputDeliveryGroupDetails
 		$xDGType = "Random Desktops and applications"
 	}
 	
-	$xDeliveryType = ""
-	Switch ($Group.DeliveryType)
-	{
-		"DesktopsOnly"	{$xDeliveryType = "Desktops"; Break}
-		"AppsOnly"		{$xDeliveryType = "Applications"; Break}
-		"DesktopsAndApps"	{$xDeliveryType = "Desktops and applications"; Break}
-		Default	{"Delivery Type could not be determined: $($Group.DeliveryType)"; Break}
-	}
-		
 	$xVDAVersion = ""
 	Switch ($Group.MinimumFunctionalLevel)
 	{
@@ -10920,7 +10947,10 @@ Function OutputApplications
 			}
 			
 			OutputApplicationDetails $Application
-			OutputApplicationSessions $Application
+			If($NoSessions -eq $False) #V1.44
+			{
+				OutputApplicationSessions $Application
+			}
 			OutputApplicationAdministrators $Application
 		}
 	}
@@ -11985,6 +12015,7 @@ Function validObject( [object] $object, [string] $topLevel )
 Function ProcessCitrixPolicies
 {
 	Param([string]$xDriveName, [string]$xPolicyType)
+	#updated to match updates in the V2 script
 
 	Write-Verbose "$(Get-Date): `tRetrieving all $($xPolicyType) policy names"
 
@@ -12060,7 +12091,7 @@ Function ProcessCitrixPolicies
 				$Script:TotalUserPolicies++
 			}
 			$Script:TotalPolicies++
-
+			
 			If($MSWord -or $PDF)
 			{
 				$selection.InsertNewPage()
@@ -12074,10 +12105,10 @@ Function ProcessCitrixPolicies
 				}
 				[System.Collections.Hashtable[]] $ScriptInformation = @()
 			
-				$ScriptInformation += @{ Data = "Description"; Value = $Policy.Description; }
-				$ScriptInformation += @{ Data = "Enabled"; Value = $Policy.Enabled.ToString(); }
-				$ScriptInformation += @{ Data = "Type"; Value = $Policy.Type; }
-				$ScriptInformation += @{ Data = "Priority"; Value = $Policy.Priority; }
+				$ScriptInformation += @{Data = "Description"; Value = $Policy.Description; }
+				$ScriptInformation += @{Data = "Enabled"; Value = $Policy.Enabled; }
+				$ScriptInformation += @{Data = "Type"; Value = $Policy.Type; }
+				$ScriptInformation += @{Data = "Priority"; Value = $Policy.Priority; }
 				
 				$Table = AddWordTable -Hashtable $ScriptInformation `
 				-Columns Data,Value `
@@ -12109,7 +12140,7 @@ Function ProcessCitrixPolicies
 				{
 					Line 1 "Description`t: " $Policy.Description
 				}
-				Line 1 "Enabled`t`t: " $Policy.Enabled.ToString()
+				Line 1 "Enabled`t`t: " $Policy.Enabled
 				Line 1 "Type`t`t: " $Policy.Type
 				Line 1 "Priority`t: " $Policy.Priority
 			}
@@ -12124,10 +12155,10 @@ Function ProcessCitrixPolicies
 					WriteHTMLLine 2 0 "$($Policy.PolicyName) (AD, $($xPolicyType))"
 				}
 				$rowdata = @()
-				$columnHeaders = @("Description",($htmlsilver -bor $htmlbold),$Policy.Description,$htmlwhite)
-				$rowdata += @(,('Enabled',($htmlsilver -bor $htmlbold),$Policy.Enabled.ToString(),$htmlwhite))
-				$rowdata += @(,('Type',($htmlsilver -bor $htmlbold),$Policy.Type,$htmlwhite))
-				$rowdata += @(,('Priority',($htmlsilver -bor $htmlbold),$Policy.Priority,$htmlwhite))
+				$columnHeaders = @("Description",($global:htmlsb),$Policy.Description,$htmlwhite)
+				$rowdata += @(,('Enabled',($global:htmlsb),$Policy.Enabled.ToString(),$htmlwhite))
+				$rowdata += @(,('Type',($global:htmlsb),$Policy.Type,$htmlwhite))
+				$rowdata += @(,('Priority',($global:htmlsb),$Policy.Priority,$htmlwhite))
 
 				$msg = ""
 				$columnWidths = @("90","200")
@@ -12173,7 +12204,7 @@ Function ProcessCitrixPolicies
 					ForEach($Filter in $Filters)
 					{
 						$tmp = ""
-						#14-Jun-2017 add back the WorkerGroup filter for xenapp 6.x
+						#5-May-2017 add back the WorkerGroup filter for xenapp 6.x
 						Switch($filter.FilterType)
 						{
 							"AccessControl"  {$tmp = "Access Control"; Break}
@@ -12191,14 +12222,13 @@ Function ProcessCitrixPolicies
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$FiltersWordTable += @{
 							Name = $filter.FilterName;
 							Type= $tmp;
 							Enabled = $filter.Enabled;
 							Mode = $filter.Mode;
 							Value = $filter.FilterValue;
 							}
-							$FiltersWordTable += $WordTableRowHash;
 						}
 						ElseIf($Text)
 						{
@@ -12214,7 +12244,7 @@ Function ProcessCitrixPolicies
 							$rowdata += @(,(
 							$filter.FilterName,$htmlwhite,
 							$tmp,$htmlwhite,
-							$filter.Enabled,$htmlwhite,
+							$filter.Enabled.ToString(),$htmlwhite,
 							$filter.Mode,$htmlwhite,
 							$filter.FilterValue,$htmlwhite))
 						}
@@ -12244,11 +12274,11 @@ Function ProcessCitrixPolicies
 					ElseIf($HTML)
 					{
 						$columnHeaders = @(
-						'Name',($htmlsilver -bor $htmlbold),
-						'Type',($htmlsilver -bor $htmlbold),
-						'Enabled',($htmlsilver -bor $htmlbold),
-						'Mode',($htmlsilver -bor $htmlbold),
-						'Value',($htmlsilver -bor $htmlbold))
+						'Name',($global:htmlsb),
+						'Type',($global:htmlsb),
+						'Enabled',($global:htmlsb),
+						'Mode',($global:htmlsb),
+						'Value',($global:htmlsb))
 
 						$msg = ""
 						$columnWidths = @("115","125","50","40","170")
@@ -12356,7 +12386,7 @@ Function ProcessCitrixPolicies
 						ElseIf($Text)
 						{
 							Line 1 $txt
-						}	
+						}
 						ElseIf($HTML)
 						{
 							WriteHTMLLine 3 0 $txt
@@ -12371,11 +12401,10 @@ Function ProcessCitrixPolicies
 						$txt = "Connector for Configuration Manager 2012\Advance warning frequency interval"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AdvanceWarningFrequency.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12406,11 +12435,10 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -12427,11 +12455,10 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = "";
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -12441,7 +12468,7 @@ Function ProcessCitrixPolicies
 								}
 								ElseIf($Text)
 								{
-									OutputPolicySetting "" $tmp
+									OutputPolicySetting "`t`t`t`t`t`t`t`t`t      " $tmp
 								}
 							}
 							$txt = ""
@@ -12454,11 +12481,10 @@ Function ProcessCitrixPolicies
 						$txt = "Connector for Configuration Manager 2012\Advance warning message box title"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AdvanceWarningMessageTitle.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12476,11 +12502,10 @@ Function ProcessCitrixPolicies
 						$txt = "Connector for Configuration Manager 2012\Advance warning time period"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AdvanceWarningPeriod.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12511,11 +12536,10 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -12532,11 +12556,10 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = "";
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -12546,7 +12569,7 @@ Function ProcessCitrixPolicies
 								}
 								ElseIf($Text)
 								{
-									OutputPolicySetting "" $tmp
+									OutputPolicySetting "`t`t`t`t`t`t`t`t`t" $tmp
 								}
 							}
 						}
@@ -12558,11 +12581,10 @@ Function ProcessCitrixPolicies
 						$txt = "Connector for Configuration Manager 2012\Final force logoff message box title"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FinalForceLogoffMessageTitle.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12580,11 +12602,10 @@ Function ProcessCitrixPolicies
 						$txt = "Connector for Configuration Manager 2012\Force logoff grace period"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ForceLogoffGracePeriod.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12615,11 +12636,10 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -12636,11 +12656,10 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = "";
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -12650,7 +12669,7 @@ Function ProcessCitrixPolicies
 								}
 								ElseIf($Text)
 								{
-									OutputPolicySetting "" $tmp
+									OutputPolicySetting "`t`t`t`t`t`t`t`t`t   " $tmp
 								}
 							}
 							$txt = ""
@@ -12663,11 +12682,10 @@ Function ProcessCitrixPolicies
 						$txt = "Connector for Configuration Manager 2012\Force logoff message box title"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ForceLogoffMessageTitle.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12685,11 +12703,10 @@ Function ProcessCitrixPolicies
 						$txt = "Connector for Configuration Manager 2012\Image-managed mode"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ImageProviderIntegrationEnabled.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12707,11 +12724,10 @@ Function ProcessCitrixPolicies
 						$txt = "Connector for Configuration Manager 2012\Reboot message box body text"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.RebootMessageBody.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12729,11 +12745,10 @@ Function ProcessCitrixPolicies
 						$txt = "Connector for Configuration Manager 2012\Regular time interval at which the agent task is to run"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AgentTaskInterval.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12748,16 +12763,36 @@ Function ProcessCitrixPolicies
 					}
 					
 					Write-Verbose "$(Get-Date): `t`t`tICA"
+					If((validStateProp $Setting ApplicationLaunchWaitTimeout State ) -and ($Setting.ApplicationLaunchWaitTimeout.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Application Launch Wait Timeout (milliseconds)"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ApplicationLaunchWaitTimeout.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ApplicationLaunchWaitTimeout.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ApplicationLaunchWaitTimeout.Value
+						}
+					}
 					If((validStateProp $Setting ClipboardRedirection State ) -and ($Setting.ClipboardRedirection.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Client clipboard redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClipboardRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12790,11 +12825,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = $txt;
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -12811,11 +12845,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -12838,11 +12871,10 @@ Function ProcessCitrixPolicies
 							$tmp = "No Client clipboard write allowed formats were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -12856,16 +12888,47 @@ Function ProcessCitrixPolicies
 							}
 						}
 					}
+					If((validStateProp $Setting ClipboardSelectionUpdateMode State ) -and ($Setting.ClipboardSelectionUpdateMode.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Clipboard selection update mode"
+						$tmp = ""
+						Switch ($Setting.ClipboardSelectionUpdateMode.Value)
+						{
+							"AllUpdatesAllowed"		{$tmp = "Selection changes are updated on both client and host"; Break}
+							"AllUpdatesDenied"		{$tmp = "Select changes are not updated on neither client nor host"; Break}
+							"UpdateToClientDenied"	{$tmp = "Host selection changes are not updated to client"; Break}
+							"UpdateToHostDenied"	{$tmp = "Client selection changes are not updated to host"; Break}
+							Default					{$tmp = "Clipboard selection update mode: $($Setting.ClipboardSelectionUpdateMode.Value)"; Break}
+						}
+						
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+						$tmp = $Null
+					}
 					If((validStateProp $Setting DesktopLaunchForNonAdmins State ) -and ($Setting.DesktopLaunchForNonAdmins.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Desktop launches"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.DesktopLaunchForNonAdmins.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12878,16 +12941,79 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.DesktopLaunchForNonAdmins.State 
 						}
 					}
+					If((validStateProp $Setting HDXEnlightenedDataTransport State ) -and ($Setting.HDXEnlightenedDataTransport.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\HDX Enlightened Data Transport (For Evaluation Only)"
+						$tmp = ""
+						Switch ($Setting.HDXEnlightenedDataTransport.Value)
+						{
+							"DiagnosticMode"	{$tmp = "Diagnostic mode"; Break}
+							"Off"				{$tmp = "Off"; Break}
+							"Preferred"			{$tmp = "Preferred"; Break}
+							Default {$tmp = "HDX Enlightened Data Transport: $($Setting.HDXEnlightenedDataTransport.Value)"; Break}
+						}
+						
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+						$tmp = $Null
+					}
+					If((validStateProp $Setting HDXAdaptiveTransport State ) -and ($Setting.HDXAdaptiveTransport.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\HDX Adaptive Transport"
+						$tmp = ""
+						Switch ($Setting.HDXAdaptiveTransport.Value)
+						{
+							"DiagnosticMode"	{$tmp = "Diagnostic mode"; Break}
+							"Off"				{$tmp = "Off"; Break}
+							"Preferred"			{$tmp = "Preferred"; Break}
+							Default {$tmp = "HDX Adaptive Transport: $($Setting.HDXAdaptiveTransport.Value)"; Break}
+						}
+						
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+						$tmp = $Null
+					}
 					If((validStateProp $Setting IcaListenerTimeout State ) -and ($Setting.IcaListenerTimeout.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\ICA listener connection timeout (milliseconds)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.IcaListenerTimeout.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12905,11 +13031,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\ICA listener port number"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.IcaListenerPortNumber.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12927,35 +13052,254 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Launching of non-published programs during client connection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
-							Value = $Setting.NonPublishedProgramLaunching.Value;
+							Value = $Setting.NonPublishedProgramLaunching.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
 							$rowdata += @(,(
 							$txt,$htmlbold,
-							$Setting.NonPublishedProgramLaunching.Value,$htmlwhite))
+							$Setting.NonPublishedProgramLaunching.State,$htmlwhite))
 						}
 						ElseIf($Text)
 						{
-							OutputPolicySetting $txt $Setting.NonPublishedProgramLaunching.Value 
+							OutputPolicySetting $txt $Setting.NonPublishedProgramLaunching.State
 						}
 					}
-
+					If((validStateProp $Setting LogoffCheckerStartupDelay State ) -and ($Setting.LogoffCheckerStartupDelay.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Logoff Checker Startup Delay (seconds)"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.LogoffCheckerStartupDelay.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.LogoffCheckerStartupDelay.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.LogoffCheckerStartupDelay.Value 
+						}
+					}
+					If((validStateProp $Setting PrimarySelectionUpdateMode State ) -and ($Setting.PrimarySelectionUpdateMode.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Primary selection update mode"
+						$tmp = ""
+						Switch ($Setting.PrimarySelectionUpdateMode.Value)
+						{
+							"AllUpdatesAllowed"		{$tmp = "Selection changes are updated on both client and host"; Break}
+							"AllUpdatesDenied"		{$tmp = "Select changes are not updated on neither client nor host"; Break}
+							"UpdateToClientDenied"	{$tmp = "Host selection changes are not updated to client"; Break}
+							"UpdateToHostDenied"	{$tmp = "Client selection changes are not updated to host"; Break}
+							Default					{$tmp = "Clipboard selection update mode: $($Setting.PrimarySelectionUpdateMode.Value)"; Break}
+						}
+						
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+						$tmp = $Null
+					}
+					If((validStateProp $Setting ReadonlyClipboard State ) -and ($Setting.ReadonlyClipboard.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Readonly Clipboard"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ReadonlyClipboard.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ReadonlyClipboard.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ReadonlyClipboard.State 
+						}
+					}
+					If((validStateProp $Setting RendezvousProtocol State ) -and ($Setting.RendezvousProtocol.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Rendezvous Protocol"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.RendezvousProtocol.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.RendezvousProtocol.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.RendezvousProtocol.State 
+						}
+					}
+					If((validStateProp $Setting RestrictClientClipboardWrite State ) -and ($Setting.RestrictClientClipboardWrite.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Restrict client clipboard write"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.RestrictClientClipboardWrite.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.RestrictClientClipboardWrite.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.RestrictClientClipboardWrite.State
+						}
+					}
+					If((validStateProp $Setting RestrictSessionClipboardWrite State ) -and ($Setting.RestrictSessionClipboardWrite.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Restrict session clipboard write"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.RestrictSessionClipboardWrite.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.RestrictSessionClipboardWrite.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.RestrictSessionClipboardWrite.State 
+						}
+					}
+					If((validStateProp $Setting SessionClipboardWriteAllowedFormats State ) -and ($Setting.SessionClipboardWriteAllowedFormats.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Session clipboard write allowed formats"
+						If(validStateProp $Setting SessionClipboardWriteAllowedFormats Values )
+						{
+							$tmpArray = $Setting.SessionClipboardWriteAllowedFormats.Values
+							$tmp = ""
+							$cnt = 0
+							ForEach($Thing in $TmpArray)
+							{
+								If($Null -eq $Thing)
+								{
+									$Thing = ''
+								}
+								$cnt++
+								$tmp = "$($Thing) "
+								If($cnt -eq 1)
+								{
+									If($MSWord -or $PDF)
+									{
+										$SettingsWordTable += @{
+										Text = $txt;
+										Value = $tmp;
+										}
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										$txt,$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting $txt $tmp
+									}
+								}
+								Else
+								{
+									If($MSWord -or $PDF)
+									{
+										$SettingsWordTable += @{
+										Text = "";
+										Value = $tmp;
+										}
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
+								}
+								$txt = ""
+							}
+							$TmpArray = $Null
+							$tmp = $Null
+						}
+						Else
+						{
+							$tmp = "No Session clipboard write allowed formats were found"
+							If($MSWord -or $PDF)
+							{
+								$SettingsWordTable += @{
+								Text = $txt;
+								Value = $tmp;
+								}
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp
+							}
+						}
+					}
+					
 					Write-Verbose "$(Get-Date): `t`t`tICA\Adobe Flash Delivery\Flash Redirection"
 					If((validStateProp $Setting FlashAcceleration State ) -and ($Setting.FlashAcceleration.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash acceleration"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FlashAcceleration.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -12988,11 +13332,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = $txt;
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -13009,11 +13352,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -13035,11 +13377,10 @@ Function ProcessCitrixPolicies
 							$tmp = "No Flash background color list were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -13058,11 +13399,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash backwards compatibility"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FlashBackwardsCompatibility.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13077,23 +13417,22 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting FlashDefaultBehavior State ) -and ($Setting.FlashDefaultBehavior.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash Default behavior"
+						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash default behavior"
 						$tmp = ""
 						Switch ($Setting.FlashDefaultBehavior.Value)
 						{
-							"Block"   {$tmp = "Block Flash player"; Break}
-							"Disable" {$tmp = "Disable Flash acceleration"; Break}
-							"Enable"  {$tmp = "Enable Flash acceleration"; Break}
-							Default {$tmp = "Flash Default behavior could not be determined: $($Setting.FlashDefaultBehavior.Value)"; Break}
+							"Block"		{$tmp = "Block Flash player"; Break}
+							"Disable"	{$tmp = "Disable Flash acceleration"; Break}
+							"Enable"	{$tmp = "Enable Flash acceleration"; Break}
+							Default		{$tmp = "Flash Default behavior could not be determined: $($Setting.FlashDefaultBehavior.Value)"; Break}
 						}
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13112,11 +13451,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash event logging"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FlashEventLogging.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13134,11 +13472,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash intelligent fallback"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FlashIntelligentFallback.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13156,11 +13493,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash latency threshold (milliseconds)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FlashLatencyThreshold.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13193,11 +13529,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = $txt;
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -13214,11 +13549,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -13240,11 +13574,10 @@ Function ProcessCitrixPolicies
 							$tmp = "No Flash server-side content fetching URL list were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -13261,26 +13594,25 @@ Function ProcessCitrixPolicies
 					If((validStateProp $Setting FlashUrlCompatibilityList State ) -and ($Setting.FlashUrlCompatibilityList.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash URL compatibility list"
-						If($MSWord -or $PDF)
-						{
-							$WordTableRowHash = @{
-							Text = $txt;
-							Value = "";
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							"",$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting $txt
-						}
 						If(validStateProp $Setting FlashUrlCompatibilityList Values )
 						{
+							If($MSWord -or $PDF)
+							{
+								$SettingsWordTable += @{
+								Text = $txt;
+								Value = "";
+								}
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								"",$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt
+							}
 							$Values = $Setting.FlashUrlCompatibilityList.Values
 							$tmp = ""
 							ForEach($Value in $Values)
@@ -13311,11 +13643,10 @@ Function ProcessCitrixPolicies
 								$tmp = "Action: $($Action)"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = "";
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -13330,11 +13661,10 @@ Function ProcessCitrixPolicies
 								$tmp = "URL Pattern: $($Url)"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = "";
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -13349,11 +13679,10 @@ Function ProcessCitrixPolicies
 								$tmp = "Flash Instance: $($FlashInstance)"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = "";
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -13377,21 +13706,20 @@ Function ProcessCitrixPolicies
 							$tmp = "No Flash URL compatibility list were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
-								Text = "";
+								$SettingsWordTable += @{
+								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
 								$rowdata += @(,(
-								"",$htmlbold,
+								$txt,$htmlbold,
 								$tmp,$htmlwhite))
 							}
 							ElseIf($Text)
 							{
-								OutputPolicySetting "" $tmp
+								OutputPolicySetting $txt $tmp
 							}
 						}
 					}
@@ -13401,19 +13729,19 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.HDXFlashLoadManagement.Value)
 						{
-							"Small"   {$tmp = "Only small content"; Break}
-							"SmallContentWRedirection" {$tmp = "Only small content with a supported client"; Break}
-							"NoServerSide"  {$tmp = "No server side content"; Break}
-							Default {$tmp = "Flash video fallback prevention could not be determined: $($Setting.HDXFlashLoadManagement.Value)"; Break}
+							"Small"						{$tmp = "Only small content"; Break}
+							"SmallContentWRedirection"	{$tmp = "Only small content with a supported client"; Break}
+							"NoServerSide"				{$tmp = "No server side content"; Break}
+							"Unconfigured"				{$tmp = "Not Configured"; Break}
+							Default 					{$tmp = "Flash video fallback prevention could not be determined: $($Setting.HDXFlashLoadManagement.Value)"; Break}
 						}
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13432,11 +13760,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash video fallback prevention error *.swf"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.HDXFlashLoadManagementErrorSwf.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13453,14 +13780,13 @@ Function ProcessCitrixPolicies
 					Write-Verbose "$(Get-Date): `t`t`tICA\Audio"
 					If((validStateProp $Setting AllowRtpAudio State ) -and ($Setting.AllowRtpAudio.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Audio\Audio over UDP Real-time Transport"
+						$txt = "ICA\Audio\Audio over UDP real-time transport"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AllowRtpAudio.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13478,11 +13804,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Audio\Audio Plug N Play"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AudioPlugNPlay.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13501,19 +13826,18 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.AudioQuality.Value)
 						{
-							"Low"    {$tmp = "Low - for low-speed connections"; Break}
-							"Medium" {$tmp = "Medium - optimized for speech"; Break}
-							"High"   {$tmp = "High - high definition audio"; Break}
-							Default {$tmp = "Audio quality could not be determined: $($Setting.AudioQuality.Value)"; Break}
+							"Low"		{$tmp = "Low - for low-speed connections"; Break}
+							"Medium"	{$tmp = "Medium - optimized for speech"; Break}
+							"High"		{$tmp = "High - high definition audio"; Break}
+							Default		{$tmp = "Audio quality could not be determined: $($Setting.AudioQuality.Value)"; Break}
 						}
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13532,11 +13856,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Audio\Client audio redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientAudioRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13554,11 +13877,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Audio\Client microphone redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MicrophoneRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13578,11 +13900,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Auto Client Reconnect\Auto client reconnect"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AutoClientReconnect.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13607,11 +13928,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13637,11 +13957,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13655,6 +13974,48 @@ Function ProcessCitrixPolicies
 						}
 						$tmp = $Null
 					}
+					If((validStateProp $Setting ACRTimeout State ) -and ($Setting.ACRTimeout.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Auto Client Reconnect\Auto client reconnect timeout (seconds)"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ACRTimeout.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ACRTimeout.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ACRTimeout.Value 
+						}
+					}
+					If((validStateProp $Setting ReconnectionUiTransparencyLevel State ) -and ($Setting.ReconnectionUiTransparencyLevel.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Auto Client Reconnect\Reconnection UI transparency level (%)"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ReconnectionUiTransparencyLevel.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ReconnectionUiTransparencyLevel.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ReconnectionUiTransparencyLevel.Value 
+						}
+					}
 					
 					Write-Verbose "$(Get-Date): `t`t`tICA\Bandwidth"
 					If((validStateProp $Setting AudioBandwidthLimit State ) -and ($Setting.AudioBandwidthLimit.State -ne "NotConfigured"))
@@ -13662,11 +14023,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\Audio redirection bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AudioBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13684,11 +14044,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\Audio redirection bandwidth limit %"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AudioBandwidthPercent.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13706,11 +14065,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\Client USB device redirection bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.USBBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13728,11 +14086,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\Client USB device redirection bandwidth limit %"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.USBBandwidthPercent.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13750,11 +14107,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\Clipboard redirection bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClipboardBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13772,11 +14128,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\Clipboard redirection bandwidth limit %"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClipboardBandwidthPercent.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13794,11 +14149,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\COM port redirection bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ComPortBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13816,11 +14170,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\COM port redirection bandwidth limit %"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ComPortBandwidthPercent.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13838,11 +14191,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\File redirection bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FileRedirectionBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13860,11 +14212,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\File redirection bandwidth limit %"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FileRedirectionBandwidthPercent.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13882,11 +14233,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\HDX MediaStream Multimedia Acceleration bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.HDXMultimediaBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13904,11 +14254,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\HDX MediaStream Multimedia Acceleration bandwidth limit %"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.HDXMultimediaBandwidthPercent.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13926,11 +14275,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\LPT port redirection bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LptBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13948,11 +14296,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\LPT port redirection bandwidth limit %"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LptBandwidthLimitPercent.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13970,11 +14317,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\Overall session bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.OverallBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -13992,11 +14338,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\Printer redirection bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.PrinterBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14014,11 +14359,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\Printer redirection bandwidth limit %"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.PrinterBandwidthPercent.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14036,11 +14380,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\TWAIN device redirection bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.TwainBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14058,11 +14401,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Bandwidth\TWAIN device redirection bandwidth limit %"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.TwainBandwidthPercent.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14082,11 +14424,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Client Sensors\Location\Allow applications to use the physical location of the client device"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AllowLocationServices.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14106,11 +14447,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Desktop UI\Aero Redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AeroRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14125,14 +14465,13 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting GraphicsQuality State ) -and ($Setting.GraphicsQuality.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Desktop UI\Aero Redirection Graphics Quality"
+						$txt = "ICA\Desktop UI\Desktop Composition graphics quality"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.GraphicsQuality.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14145,16 +14484,36 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.GraphicsQuality.Value 
 						}
 					}
+					If((validStateProp $Setting AeroRedirection State ) -and ($Setting.AeroRedirection.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Desktop UI\Desktop Composition Redirection"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.AeroRedirection.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.AeroRedirection.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.AeroRedirection.State 
+						}
+					}
 					If((validStateProp $Setting DesktopWallpaper State ) -and ($Setting.DesktopWallpaper.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Desktop UI\Desktop wallpaper"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.DesktopWallpaper.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14172,11 +14531,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Desktop UI\Menu animation"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MenuAnimation.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14194,11 +14552,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Desktop UI\View window contents while dragging"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.WindowContentsVisibleWhileDragging.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14218,11 +14575,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\End User Monitoring\ICA round trip calculation"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.IcaRoundTripCalculation.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14240,11 +14596,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\End User Monitoring\ICA round trip calculation interval (seconds)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.IcaRoundTripCalculationInterval.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14262,11 +14617,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\End User Monitoring\ICA round trip calculations for idle connections"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.IcaRoundTripCalculationWhenIdle.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14286,11 +14640,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Enhanced Desktop Experience\Enhanced Desktop Experience"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.EnhancedDesktopExperience.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14310,11 +14663,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Allow file transfer between desktop and client"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AllowFileTransfer.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14332,11 +14684,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Auto connect client drives"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AutoConnectDrives.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14354,11 +14705,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Client drive redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientDriveRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14376,11 +14726,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Client fixed drives"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientFixedDrives.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14398,11 +14747,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Client floppy drives"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientFloppyDrives.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14420,11 +14768,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Client network drives"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientNetworkDrives.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14442,11 +14789,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Client optical drives"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientOpticalDrives.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14464,11 +14810,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Client removable drives"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientRemoveableDrives.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14486,11 +14831,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Download file from desktop"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AllowFileDownload.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14508,11 +14852,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Host to client redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.HostToClientRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14530,11 +14873,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Preserve client drive letters"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientDriveLetterPreservation.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14552,11 +14894,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Read-only client drive access"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ReadOnlyMappedDrive.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14574,11 +14915,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Special folder redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SpecialFolderRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14596,11 +14936,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Upload file to desktop"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AllowFileUpload.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14618,11 +14957,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\File Redirection\Use asynchronous writes"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AsynchronousWrites.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14642,11 +14980,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Graphics\Allow visually lossless compression"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AllowVisuallyLosslessCompression.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14659,16 +14996,37 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.AllowVisuallyLosslessCompression.State 
 						}
 					}
+					If((validStateProp $Setting DisplayLosslessIndicator State ) -and ($Setting.DisplayLosslessIndicator.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Graphics\Display lossless indicator"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.DisplayLosslessIndicator.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.DisplayLosslessIndicator.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.DisplayLosslessIndicator.State 
+						}
+					}
 					If((validStateProp $Setting DisplayMemoryLimit State ) -and ($Setting.DisplayMemoryLimit.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Graphics\Display memory limit (KB)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.DisplayMemoryLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14687,17 +15045,16 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.DisplayDegradePreference.Value)
 						{
-							"ColorDepth" {$tmp = "Degrade color depth first"; Break}
-							"Resolution" {$tmp = "Degrade resolution first"; Break}
-							Default {$tmp = "Display mode degrade preference could not be determined: $($Setting.DisplayDegradePreference.Value)"; Break}
+							"ColorDepth"	{$tmp = "Degrade color depth first"; Break}
+							"Resolution"	{$tmp = "Degrade resolution first"; Break}
+							Default			{$tmp = "Display mode degrade preference could not be determined: $($Setting.DisplayDegradePreference.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14713,14 +15070,13 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting DynamicPreview State ) -and ($Setting.DynamicPreview.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Graphics\Dynamic Windows Preview"
+						$txt = "ICA\Graphics\Dynamic windows preview"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.DynamicPreview.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14738,11 +15094,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Graphics\Image caching"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ImageCaching.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14760,11 +15115,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Graphics\Legacy graphics mode"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LegacyGraphicsMode.State;
-						}
-							$SettingsWordTable += $WordTableRowHash;
+							}
 						}
 						ElseIf($HTML)
 						{
@@ -14792,11 +15146,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14815,11 +15168,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Graphics\Notify user when display mode is degraded"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.DisplayDegradeUserNotification.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14832,16 +15184,37 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.DisplayDegradeUserNotification.State 
 						}	
 					}
+					If((validStateProp $Setting OptimizeFor3dWorkload State ) -and ($Setting.OptimizeFor3dWorkload.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Graphics\Optimize for 3D graphics workload"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.OptimizeFor3dWorkload.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.OptimizeFor3dWorkload.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.OptimizeFor3dWorkload.State 
+						}
+					}
 					If((validStateProp $Setting QueueingAndTossing State ) -and ($Setting.QueueingAndTossing.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Graphics\Queueing and tossing"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.QueueingAndTossing.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14852,6 +15225,27 @@ Function ProcessCitrixPolicies
 						ElseIf($Text)
 						{
 							OutputPolicySetting $txt $Setting.QueueingAndTossing.State 
+						}	
+					}
+					If((validStateProp $Setting UseHardwareEncodingForVideoCodec State ) -and ($Setting.UseHardwareEncodingForVideoCodec.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Graphics\Use hardware encoding for video codec"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.UseHardwareEncodingForVideoCodec.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.UseHardwareEncodingForVideoCodec.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.UseHardwareEncodingForVideoCodec.State 
 						}	
 					}
 					If((validStateProp $Setting UseVideoCodecForCompression State ) -and ($Setting.UseVideoCodecForCompression.State -ne "NotConfigured"))
@@ -14868,11 +15262,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14893,11 +15286,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Graphics\Caching\Persistent cache threshold (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.PersistentCache.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14917,11 +15309,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Graphics\Framehawk\Framehawk display channel"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.EnableFramehawkDisplayChannel.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14939,11 +15330,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Graphics\Framehawk\Framehawk display channel port range"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FramehawkDisplayChannelPortRange.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14963,11 +15353,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Keep Alive\ICA keep alive timeout (seconds)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.IcaKeepAliveTimeout.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -14992,11 +15381,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15017,11 +15405,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Local App Access\Allow local app access"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AllowLocalAppAccess.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15054,11 +15441,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = $txt;
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -15075,11 +15461,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -15101,11 +15486,10 @@ Function ProcessCitrixPolicies
 							$tmp = "No URL redirection blacklist were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -15139,11 +15523,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = $txt;
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -15160,11 +15543,10 @@ Function ProcessCitrixPolicies
 								{
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -15186,11 +15568,10 @@ Function ProcessCitrixPolicies
 							$tmp = "No URL redirection white list were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -15211,11 +15592,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Mobile Experience\Automatic keyboard display"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AutoKeyboardPopUp.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15233,11 +15613,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Mobile Experience\Launch touch-optimized desktop"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MobileDesktop.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15255,11 +15634,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Mobile Experience\Remote the combo box"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ComboboxRemoting.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15272,8 +15650,283 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.ComboboxRemoting.State 
 						}
 					}
+					If((validStateProp $Setting TabletModeToggle State ) -and ($Setting.TabletModeToggle.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Mobile Experience\Tablet Mode Toggle"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.TabletModeToggle.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.TabletModeToggle.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.TabletModeToggle.State 
+						}
+					}
 					
 					Write-Verbose "$(Get-Date): `t`t`tICA\Multimedia"
+					If((validStateProp $Setting WebBrowserRedirection State ) -and ($Setting.WebBrowserRedirection.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Multimedia\Browser Content Redirection"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.WebBrowserRedirection.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.WebBrowserRedirection.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.WebBrowserRedirection.State
+						}
+					}
+					If((validStateProp $Setting BRUrlWhitelist State ) -and ($Setting.BRUrlWhitelist.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Multimedia\Browser Content Redirection ACL Configuration"
+						$array = $Setting.BRUrlWhitelist.Values.Split(';')
+						$tmp = $array[0]
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+
+						$txt = ""
+						$cnt = -1
+						ForEach($element in $array)
+						{
+							$cnt++
+							
+							If($cnt -ne 0)
+							{
+								$tmp = "$($element) "
+								If($MSWord -or $PDF)
+								{
+									$SettingsWordTable += @{
+									Text = "";
+									Value = $tmp;
+									}
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									"",$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting "" $tmp
+								}
+							}
+						}
+						$array = $Null
+						$tmp = $Null
+					}
+					If((validStateProp $Setting WebBrowserRedirectionAuthenticationSites State ) -and ($Setting.WebBrowserRedirectionAuthenticationSites.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Multimedia\Browser Content Redirection Authentication Sites"
+						$array = $Setting.WebBrowserRedirectionAuthenticationSites.Values.Split(';')
+						$tmp = $array[0]
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+
+						$txt = ""
+						$cnt = -1
+						ForEach($element in $array)
+						{
+							$cnt++
+							
+							If($cnt -ne 0)
+							{
+								$tmp = "$($element) "
+								If($MSWord -or $PDF)
+								{
+									$SettingsWordTable += @{
+									Text = "";
+									Value = $tmp;
+									}
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									"",$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting "" $tmp
+								}
+							}
+						}
+						$array = $Null
+						$tmp = $Null
+					}
+					If((validStateProp $Setting WebBrowserRedirectionBlacklist State ) -and ($Setting.WebBrowserRedirectionBlacklist.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Multimedia\Browser Content Redirection Blacklist Configuration"
+						$array = $Setting.WebBrowserRedirectionBlacklist.Values.Split(';')
+						$tmp = $array[0]
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+
+						$txt = ""
+						$cnt = -1
+						ForEach($element in $array)
+						{
+							$cnt++
+							
+							If($cnt -ne 0)
+							{
+								$tmp = "$($element) "
+								If($MSWord -or $PDF)
+								{
+									$SettingsWordTable += @{
+									Text = "";
+									Value = $tmp;
+									}
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									"",$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting "" $tmp
+								}
+							}
+						}
+						$array = $Null
+						$tmp = $Null
+					}
+					If((validStateProp $Setting WebBrowserRedirectionProxy State ) -and ($Setting.WebBrowserRedirectionProxy.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Multimedia\Browser Content Redirection Proxy Configuration"
+						If($Setting.WebBrowserRedirectionProxy.State -eq "Enabled")
+						{
+							If($MSWord -or $PDF)
+							{
+								$SettingsWordTable += @{
+								Text = $txt;
+								Value = $Setting.WebBrowserRedirectionProxy.Value;
+								}
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.WebBrowserRedirectionProxy.Value,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.WebBrowserRedirectionProxy.Value 
+							}
+						}
+						Else
+						{
+							If($MSWord -or $PDF)
+							{
+								$SettingsWordTable += @{
+								Text = $txt;
+								Value = $Setting.WebBrowserRedirectionProxy.State;
+								}
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.WebBrowserRedirectionProxy.State,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.WebBrowserRedirectionProxy.State 
+							}
+						}
+					}
+					If((validStateProp $Setting HTML5VideoRedirection State ) -and ($Setting.HTML5VideoRedirection.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Multimedia\HTML5 video redirection"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.HTML5VideoRedirection.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.HTML5VideoRedirection.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.HTML5VideoRedirection.State
+						}
+					}
 					If((validStateProp $Setting VideoQuality State ) -and ($Setting.VideoQuality.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Multimedia\Limit video quality"
@@ -15290,11 +15943,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15308,16 +15960,58 @@ Function ProcessCitrixPolicies
 						}
 						$tmp = $Null
 					}
+					If((validStateProp $Setting MaxSpeexQuality State ) -and ($Setting.MaxSpeexQuality.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Multimedia\Max Speex quality"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.MaxSpeexQuality.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.MaxSpeexQuality.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.MaxSpeexQuality.Value 
+						}
+					}
+					If((validStateProp $Setting MSTeamsRedirection State ) -and ($Setting.MSTeamsRedirection.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Multimedia\Microsoft Teams redirection"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.MSTeamsRedirection.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.MSTeamsRedirection.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.MSTeamsRedirection.State 
+						}
+					}
 					If((validStateProp $Setting MultimediaConferencing State ) -and ($Setting.MultimediaConferencing.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Multimedia\Multimedia conferencing"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MultimediaConferencing.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15335,11 +16029,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Multimedia\Optimization for Windows Media multimedia redirection over WAN"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MultimediaOptimization.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15357,11 +16050,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Multimedia\Use GPU for optimizing Windows Media multimedia redirection over WAN"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.UseGPUForMultimediaOptimization.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15379,11 +16071,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Multimedia\Windows Media client-side content fetching"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MultimediaAccelerationEnableCSF.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15402,18 +16093,18 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.VideoLoadManagement.Value)
 						{
-							"SFSR" {$tmp = "Play all content"; Break}
-							"SFCR" {$tmp = "Play all content only on client"; Break}
-							"CFCR" {$tmp = "Play only client-accessible content on client"; Break}
-							Default {$tmp = "Windows media fallback prevention could not be determined: $($Setting.VideoLoadManagement.Value)"; Break}
+							"SFSR"			{$tmp = "Play all content"; Break}
+							"SFCR"			{$tmp = "Play all content only on client"; Break}
+							"CFCR"			{$tmp = "Play only client-accessible content on client"; Break}
+							"UnConfigured"	{$tmp = "Not Configured"; Break}
+							Default			{$tmp = "Windows media fallback prevention could not be determined: $($Setting.VideoLoadManagement.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15429,14 +16120,13 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting MultimediaAcceleration State ) -and ($Setting.MultimediaAcceleration.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Multimedia\Windows Media Redirection"
+						$txt = "ICA\Multimedia\Windows Media redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MultimediaAcceleration.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15451,14 +16141,13 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting MultimediaAccelerationDefaultBufferSize State ) -and ($Setting.MultimediaAccelerationDefaultBufferSize.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Multimedia\Windows Media Redirection Buffer Size (seconds)"
+						$txt = "ICA\Multimedia\Windows Media redirection buffer size (seconds)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MultimediaAccelerationDefaultBufferSize.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15473,14 +16162,13 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting MultimediaAccelerationUseDefaultBufferSize State ) -and ($Setting.MultimediaAccelerationUseDefaultBufferSize.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Multimedia\Windows Media Redirection Buffer Size Use"
+						$txt = "ICA\Multimedia\Windows Media redirection buffer size use"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MultimediaAccelerationUseDefaultBufferSize.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15495,16 +16183,36 @@ Function ProcessCitrixPolicies
 					}
 
 					Write-Verbose "$(Get-Date): `t`t`tICA\Multi-Stream Connections"
-					If((validStateProp $Setting RtpAudioPortRange State ) -and ($Setting.RtpAudioPortRange.State -ne "NotConfigured"))
+					If((validStateProp $Setting UDPAudioOnServer State ) -and ($Setting.UDPAudioOnServer.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\MultiStream Connections\Audio UDP Port Range"
+						$txt = "ICA\MultiStream Connections\Audio over UDP"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.UDPAudioOnServer.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.UDPAudioOnServer.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.UDPAudioOnServer.State
+						}
+					}
+					If((validStateProp $Setting RtpAudioPortRange State ) -and ($Setting.RtpAudioPortRange.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\MultiStream Connections\Audio UDP port range"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.RtpAudioPortRange.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15523,17 +16231,15 @@ Function ProcessCitrixPolicies
 						$txt2 = "ICA\MultiStream Connections\Multi-Port Policy\CGP default port priority"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt1;
 							Value = "Default Port";
 							}
-							$SettingsWordTable += $WordTableRowHash;
 
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt2;
 							Value = "High";
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15559,8 +16265,8 @@ Function ProcessCitrixPolicies
 							$Port2Priority = ""
 							$Port3Priority = ""
 							[string]$cgpport1 = $Tmp.substring(0, $Tmp.indexof(";"))
-							[string]$cgpport2 = $Tmp.substring($cgpport1.length + 1 , $Tmp.indexof(";"))
-							[string]$cgpport3 = $Tmp.substring((($cgpport1.length + 1)+($cgpport2.length + 1)) , $Tmp.indexof(";"))
+							[string]$cgpport2 = $Tmp.substring($cgpport1.length + 1 , ($Tmp.indexof(";")+1))
+							[string]$cgpport3 = $Tmp.substring((($cgpport1.length + 1)+($cgpport2.length + 1)) , ($Tmp.indexof(";")+1))
 							[string]$cgpport1priority = $cgpport1.substring($cgpport1.length -1, 1)
 							[string]$cgpport2priority = $cgpport2.substring($cgpport2.length -1, 1)
 							[string]$cgpport3priority = $cgpport3.substring($cgpport3.length -1, 1)
@@ -15596,41 +16302,35 @@ Function ProcessCitrixPolicies
 							$txt6 = "ICA\MultiStream Connections\Multi-Port Policy\CGP port3 priority"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt1;
 								Value = $cgpport1;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt2;
 								Value = $port1priority;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt3;
 								Value = $cgpport2;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt4;
 								Value = $port2priority;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt5;
 								Value = $cgpport3;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt6;
 								Value = $port3priority;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -15690,11 +16390,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\MultiStream Connections\Multi-Stream computer setting"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MultiStreamPolicy.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15712,11 +16411,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\MultiStream Connections\Multi-Stream user setting"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MultiStream.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15736,11 +16434,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Port Redirection\Auto connect client COM ports"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientComPortsAutoConnection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15758,11 +16455,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Port Redirection\Auto connect client LPT ports"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientLptPortsAutoConnection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15780,11 +16476,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Port Redirection\Client COM port redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientComPortRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15802,11 +16497,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Port Redirection\Client LPT port redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientLptPortRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15826,11 +16520,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Printing\Client printer redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ClientPrinterRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15855,11 +16548,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -15915,23 +16607,20 @@ Function ProcessCitrixPolicies
 									$tmp3 = "Session Printers : $($SessionPrinters)"
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = $txt;
 										Value = $tmp1;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 										
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp2;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 										
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp3;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -15963,11 +16652,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.PrinterAssignments.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -15994,11 +16682,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16019,11 +16706,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = "";
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -16052,11 +16738,10 @@ Function ProcessCitrixPolicies
 											$tmp = "Server: $($server)"
 											If($MSWord -or $PDF)
 											{
-												$WordTableRowHash = @{
+												$SettingsWordTable += @{
 												Text = "";
 												Value = $tmp;
 												}
-												$SettingsWordTable += $WordTableRowHash;
 											}
 											ElseIf($HTML)
 											{
@@ -16071,11 +16756,10 @@ Function ProcessCitrixPolicies
 											$tmp = "Shared Name: $($share)"
 											If($MSWord -or $PDF)
 											{
-												$WordTableRowHash = @{
+												$SettingsWordTable += @{
 												Text = "";
 												Value = $tmp;
 												}
-												$SettingsWordTable += $WordTableRowHash;
 											}
 											ElseIf($HTML)
 											{
@@ -16098,11 +16782,10 @@ Function ProcessCitrixPolicies
 										{
 											If($MSWord -or $PDF)
 											{
-												$WordTableRowHash = @{
+												$SettingsWordTable += @{
 												Text = "";
 												Value = $tmp;
 												}
-												$SettingsWordTable += $WordTableRowHash;
 											}
 											ElseIf($HTML)
 											{
@@ -16130,11 +16813,10 @@ Function ProcessCitrixPolicies
 							$tmp = "No Session printers were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -16150,14 +16832,13 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting WaitForPrintersToBeCreated State ) -and ($Setting.WaitForPrintersToBeCreated.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Printing\Wait for printers to be created (desktop)"
+						$txt = "ICA\Printing\Wait for printers to be created (server desktop)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.WaitForPrintersToBeCreated.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16186,11 +16867,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16209,11 +16889,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Printing\Client Printers\Auto-create generic universal printer"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.GenericUniversalPrinterAutoCreation.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16231,11 +16910,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Printing\Client Printers\Auto-create PDF Universal Printer"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AutoCreatePDFPrinter.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16260,11 +16938,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16283,11 +16960,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Printing\Client Printers\Direct connections to print servers"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.DirectConnectionsToPrintServers.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16309,11 +16985,10 @@ Function ProcessCitrixPolicies
 							$tmp = $array[0]
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -16360,11 +17035,10 @@ Function ProcessCitrixPolicies
 									$tmp = "Driver Name: $($DriverName)"
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -16376,14 +17050,13 @@ Function ProcessCitrixPolicies
 									{
 										OutputPolicySetting "`t`t`t`t`t`t`t`t     " $tmp
 									}
-									$tmp = "Action: $($Action)"
+									$tmp = "Action     : $($Action)"
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -16395,14 +17068,13 @@ Function ProcessCitrixPolicies
 									{
 										OutputPolicySetting "`t`t`t`t`t`t`t`t     " $tmp
 									}
-									$tmp = "Settings: "
+									$tmp = "Settings   : "
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -16426,11 +17098,10 @@ Function ProcessCitrixPolicies
 											{
 												If($MSWord -or $PDF)
 												{
-													$WordTableRowHash = @{
+													$SettingsWordTable += @{
 													Text = "";
 													Value = $tmp;
 													}
-													$SettingsWordTable += $WordTableRowHash;
 												}
 												ElseIf($HTML)
 												{
@@ -16450,11 +17121,10 @@ Function ProcessCitrixPolicies
 										$tmp = "Unmodified "
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -16473,11 +17143,10 @@ Function ProcessCitrixPolicies
 										$tmp = "Server Driver: $($ServerDriver)"
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -16499,11 +17168,10 @@ Function ProcessCitrixPolicies
 							$tmp = "No Printer driver mapping and compatibility were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -16532,11 +17200,10 @@ Function ProcessCitrixPolicies
 
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16555,11 +17222,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Printing\Client Printers\Retained and restored client printers"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.RetainedAndRestoredClientPrinters.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16579,11 +17245,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Printing\Drivers\Automatic installation of in-box printer drivers"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.InboxDriverAutoInstallation.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16614,11 +17279,10 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -16635,11 +17299,10 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = "";
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -16671,11 +17334,10 @@ Function ProcessCitrixPolicies
 
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16689,8 +17351,184 @@ Function ProcessCitrixPolicies
 						}
 						$tmp = $Null
 					}
-
+					
 					Write-Verbose "$(Get-Date): `t`t`tICA\Printing\Universal Print Server"
+					If((validStateProp $Setting UpcSslCipherSuite State ) -and ($Setting.UpcSslCipherSuite.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Printing\Universal Print Server\SSL Cipher Suite"
+						Switch ($Setting.UpcSslCipherSuite.Value)
+						{
+							"All"	{$tmp = "All"; Break}
+							"COM"	{$tmp = "COM"; Break}
+							"GOV"	{$tmp = "GOV"; Break}
+							Default	{$tmp = "Universal Print Server SSL Cipher Suite value could not be determined: $($Setting.UpcSslCipherSuite.Value)"; Break}
+						}
+						
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+					}
+					If((validStateProp $Setting UpcSslComplianceMode State ) -and ($Setting.UpcSslComplianceMode.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Printing\Universal Print Server\SSL Compliance Mode"
+						Switch ($Setting.UpcSslComplianceMode.Value)
+						{
+							"None"	{$tmp = "None"; Break}
+							"SP800_52"	{$tmp = "SP800-52"; Break}
+							Default	{$tmp = "Universal Print Server SSL Compliance Mode value could not be determined: $($Setting.UpcSslComplianceMode.Value)"; Break}
+						}
+						
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+					}
+					If((validStateProp $Setting UpcSslEnable State ) -and ($Setting.UpcSslEnable.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Printing\Universal Print Server\SSL Enabled"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.UpcSslEnable.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.UpcSslEnable.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.UpcSslEnable.State 
+						}
+					}
+					If((validStateProp $Setting UpcSslFips State ) -and ($Setting.UpcSslFips.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Printing\Universal Print Server\SSL FIPS Mode"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.UpcSslFips.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.UpcSslFips.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.UpcSslFips.State 
+						}
+					}
+					If((validStateProp $Setting UpcSslProtocolVersion State ) -and ($Setting.UpcSslProtocolVersion.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Printing\Universal Print Server\SSL Protocol Version"
+						Switch ($Setting.UpcSslProtocolVersion.Value)
+						{
+							"All"	{$tmp = "All"; Break}
+							"TLS1"	{$tmp = "TLSv1"; Break}
+							"TLS11"	{$tmp = "TLSv1.1"; Break}
+							"TLS12"	{$tmp = "TLSv1.2"; Break}
+							Default	{$tmp = "Universal Print Server SSL Protocol Version value could not be determined: $($Setting.UpcSslProtocolVersion.Value)"; Break}
+						}
+						
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+					}
+					If((validStateProp $Setting UpcSslCgpPort State ) -and ($Setting.UpcSslCgpPort.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Printing\Universal Print Server\SSL Universal Print Server encrypted print data stream (CGP) port"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.UpcSslCgpPort.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.UpcSslCgpPort.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.UpcSslCgpPort.Value 
+						}
+					}
+					If((validStateProp $Setting UpcSslHttpsPort State ) -and ($Setting.UpcSslHttpsPort.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Printing\Universal Print Server\SSL Universal Print Server encrypted web service (HTTPS/SOAP) port"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.UpcSslHttpsPort.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.UpcSslHttpsPort.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.UpcSslHttpsPort.Value 
+						}
+					}
 					If((validStateProp $Setting UpsEnable State ) -and ($Setting.UpsEnable.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Printing\Universal Print Server\Universal Print Server enable"
@@ -16706,16 +17544,16 @@ Function ProcessCitrixPolicies
 						{
 							"UpsEnabledWithFallback"	{$tmp = "Enabled with fallback to Windows' native remote printing"; Break}
 							"UpsOnlyEnabled"			{$tmp = "Enabled with no fallback to Windows' native remote printing"; Break}
-							Default						{$tmp = "Universal Print Server enable value could not be determined: $($Setting.UpsEnable.Value)"; Break}
+							"UpsDisabled"				{$tmp = "Disabled"; Break} 	#V1.44
+							Default	{$tmp = "Universal Print Server enable value could not be determined: $($Setting.UpsEnable.Value)"; Break}
 						}
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16733,11 +17571,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Printing\Universal Print Server\Universal Print Server print data stream (CGP) port"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.UpsCgpPort.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16752,14 +17589,13 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting UpsPrintStreamInputBandwidthLimit State ) -and ($Setting.UpsPrintStreamInputBandwidthLimit.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Printing\Universal Print Server\Universal Print Server print stream input bandwidth limit (kbps)"
+						$txt = "ICA\Printing\Universal Print Server\Universal Print Server print stream input bandwidth limit (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.UpsPrintStreamInputBandwidthLimit.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16777,11 +17613,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Printing\Universal Print Server\Universal Print Server web service (HTTP/SOAP) port"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.UpsHttpPort.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16792,6 +17627,106 @@ Function ProcessCitrixPolicies
 						ElseIf($Text)
 						{
 							OutputPolicySetting $txt $Setting.UpsHttpPort.Value 
+						}
+					}
+					If((validStateProp $Setting LoadBalancedPrintServers State ) -and ($Setting.LoadBalancedPrintServers.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Printing\Universal Print Server\Universal Print Servers for load balancing"
+						If(validStateProp $Setting LoadBalancedPrintServers Values )
+						{
+							$array = $Setting.LoadBalancedPrintServers.Values
+							$tmp = $array[0]
+							If($MSWord -or $PDF)
+							{
+								$SettingsWordTable += @{
+								Text = $txt;
+								Value = $tmp;
+								}
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
+							}
+
+							$txt = ""
+							$cnt = -1
+							
+							ForEach($element in $array)
+							{
+								$cnt++
+								
+								If($cnt -ne 0)
+								{
+									$tmp = "$($element) "
+									If($MSWord -or $PDF)
+									{
+										$SettingsWordTable += @{
+										Text = "";
+										Value = $tmp;
+										}
+									}
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										$tmp,$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
+								}
+							}
+							$array = $Null
+							$tmp = $Null
+						}
+						Else
+						{
+							$tmp = "No Universal Print Servers for load balancing were found"
+							If($MSWord -or $PDF)
+							{
+								$SettingsWordTable += @{
+								Text = $txt;
+								Value = $tmp;
+								}
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$tmp,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $tmp 
+							}
+						}
+					}
+					If((validStateProp $Setting PrintServersOutOfServiceThreshold State ) -and ($Setting.PrintServersOutOfServiceThreshold.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Printing\Universal Print Server\Universal Print Servers out-of-service threshold (seconds)"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.PrintServersOutOfServiceThreshold.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.PrintServersOutOfServiceThreshold.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.PrintServersOutOfServiceThreshold.Value 
 						}
 					}
 
@@ -16809,11 +17744,10 @@ Function ProcessCitrixPolicies
 						 
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16843,11 +17777,10 @@ Function ProcessCitrixPolicies
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16866,11 +17799,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Printing\Universal Printing\Universal printing optimization defaults"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = "";
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -16898,10 +17830,10 @@ Function ProcessCitrixPolicies
 									$TxtLabel = "Desired image quality:"
 									Switch($TestSetting)
 									{
-										"StandardQuality"	{$TxtSetting = "Standard quality"}
-										"BestQuality"	{$TxtSetting = "Best quality (lossless compression)"}
-										"HighQuality"	{$TxtSetting = "High quality"}
-										"ReducedQuality"	{$TxtSetting = "Reduced quality (maximum compression)"}
+										"StandardQuality"	{$TxtSetting = "Standard quality"; Break}
+										"BestQuality"		{$TxtSetting = "Best quality (lossless compression)"; Break}
+										"HighQuality"		{$TxtSetting = "High quality"; Break}
+										"ReducedQuality"	{$TxtSetting = "Reduced quality (maximum compression)"; Break}
 									}
 								}
 								"HeavyweightCompression"
@@ -16956,41 +17888,21 @@ Function ProcessCitrixPolicies
 							$tmp = "$($TxtLabel) $TxtSetting "
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = "";
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
 								$rowdata += @(,(
-								$txt,$htmlbold,
+								"",$htmlbold,
 								$tmp,$htmlwhite))
 							}
 							ElseIf($Text)
 							{
-								OutputPolicySetting "" $tmp
+								OutputPolicySetting "`t`t`t`t`t`t`t`t`t" $tmp
 							}
-						}
-						$tmp = " "
-						If($MSWord -or $PDF)
-						{
-							$WordTableRowHash = @{
-							Text = "";
-							Value = $tmp;
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							$tmp,$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting "" $tmp
 						}
 						$TmpArray = $Null
 						$tmp = $Null
@@ -17014,11 +17926,10 @@ Function ProcessCitrixPolicies
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17038,21 +17949,20 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.DPILimit.Value)
 						{
-							"Draft"            {$tmp = "Draft (150 DPI)"; Break}
-							"LowResolution"    {$tmp = "Low Resolution (300 DPI)"; Break}
-							"MediumResolution" {$tmp = "Medium Resolution (600 DPI)"; Break}
-							"HighResolution"   {$tmp = "High Resolution (1200 DPI)"; Break}
-							"Unlimited"       {$tmp = "No Limit"; Break}
+							"Draft"				{$tmp = "Draft (150 DPI)"; Break}
+							"LowResolution"		{$tmp = "Low Resolution (300 DPI)"; Break}
+							"MediumResolution"	{$tmp = "Medium Resolution (600 DPI)"; Break}
+							"HighResolution"	{$tmp = "High Resolution (1200 DPI)"; Break}
+							"Unlimited"			{$tmp = "No Limit"; Break}
 							Default {$tmp = "Universal printing print quality limit could not be determined: $($Setting.DPILimit.Value)"; Break}
 						}
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17074,21 +17984,20 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.MinimumEncryptionLevel.Value)
 						{
-							"Unknown" {$tmp = "Unknown encryption"; Break}
-							"Basic"   {$tmp = "Basic"; Break}
-							"LogOn"   {$tmp = "RC5 (128 bit) logon only"; Break}
-							"Bits40"  {$tmp = "RC5 (40 bit)"; Break}
-							"Bits56"  {$tmp = "RC5 (56 bit)"; Break}
-							"Bits128" {$tmp = "RC5 (128 bit)"; Break}
-							Default {$tmp = "SecureICA minimum encryption level could not be determined: $($Setting.MinimumEncryptionLevel.Value)"; Break}
+							"Unknown"	{$tmp = "Unknown encryption"; Break}
+							"Basic"		{$tmp = "Basic"; Break}
+							"LogOn"		{$tmp = "RC5 (128 bit) logon only"; Break}
+							"Bits40"	{$tmp = "RC5 (40 bit)"; Break}
+							"Bits56"	{$tmp = "RC5 (56 bit)"; Break}
+							"Bits128"	{$tmp = "RC5 (128 bit)"; Break}
+							Default		{$tmp = "SecureICA minimum encryption level could not be determined: $($Setting.MinimumEncryptionLevel.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17108,11 +18017,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Server Limits\Server idle timer interval (milliseconds)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.IdleTimerInterval.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17132,11 +18040,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Session Limits\Disconnected session timer"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SessionDisconnectTimer.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17154,11 +18061,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Session Limits\Disconnected session timer interval (minutes)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SessionDisconnectTimerInterval.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17176,11 +18082,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Session Limits\Session connection timer"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SessionConnectionTimer.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17198,11 +18103,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Session Limits\Session connection timer interval (minutes)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SessionConnectionTimerInterval.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17220,11 +18124,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Session Limits\Session idle timer"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SessionIdleTimer.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17242,11 +18145,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Session Limits\Session idle timer interval (minutes)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SessionIdleTimerInterval.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17260,17 +18162,228 @@ Function ProcessCitrixPolicies
 						}
 					}
 
+					Write-Verbose "$(Get-Date): `t`t`tICA\Session Watermark"
+					If((validStateProp $Setting EnableSessionWatermark State ) -and ($Setting.EnableSessionWatermark.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Session Watermark\Enable session watermark"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.EnableSessionWatermark.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.EnableSessionWatermark.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.EnableSessionWatermark.State 
+						}
+					}
+
+					Write-Verbose "$(Get-Date): `t`t`tICA\Session Watermark\Watermark Content"
+					If((validStateProp $Setting WatermarkIncludeClientIPAddress State ) -and ($Setting.WatermarkIncludeClientIPAddress.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Session Watermark\Watermark Content\Include client IP address"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.WatermarkIncludeClientIPAddress.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.WatermarkIncludeClientIPAddress.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.WatermarkIncludeClientIPAddress.State 
+						}
+					}
+					If((validStateProp $Setting WatermarkIncludeConnectTime State ) -and ($Setting.WatermarkIncludeConnectTime.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Session Watermark\Watermark Content\Include connection time"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.WatermarkIncludeConnectTime.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.WatermarkIncludeConnectTime.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.WatermarkIncludeConnectTime.State 
+						}
+					}
+					If((validStateProp $Setting WatermarkIncludeLogonUsername State ) -and ($Setting.WatermarkIncludeLogonUsername.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Session Watermark\Watermark Content\Include logon user name"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.WatermarkIncludeLogonUsername.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.WatermarkIncludeLogonUsername.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.WatermarkIncludeLogonUsername.State 
+						}
+					}
+					If((validStateProp $Setting WatermarkIncludeVDAHostName State ) -and ($Setting.WatermarkIncludeVDAHostName.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Session Watermark\Watermark Content\Include VDA host name"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.WatermarkIncludeVDAHostName.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.WatermarkIncludeVDAHostName.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.WatermarkIncludeVDAHostName.State 
+						}
+					}
+					If((validStateProp $Setting WatermarkIncludeVDAIPAddress State ) -and ($Setting.WatermarkIncludeVDAIPAddress.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Session Watermark\Watermark Content\Include VDA IP address"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.WatermarkIncludeVDAIPAddress.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.WatermarkIncludeVDAIPAddress.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.WatermarkIncludeVDAIPAddress.State 
+						}
+					}
+					If((validStateProp $Setting WatermarkCustomText State ) -and ($Setting.WatermarkCustomText.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Session Watermark\Watermark Content\Watermark custom text"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.WatermarkCustomText.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.WatermarkCustomText.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.WatermarkCustomText.Value 
+						}
+					}
+
+					Write-Verbose "$(Get-Date): `t`t`tICA\Session Watermark\Watermark Style"
+					If((validStateProp $Setting WatermarkStyle State ) -and ($Setting.WatermarkStyle.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Session Watermark\Watermark Style\Session watermark style"
+						$tmp = ""
+						Switch ($Setting.WatermarkStyle.Value)
+						{
+							"StyleMutiple" {$tmp = "Multiple"; Break}
+							"StyleSingle"   {$tmp = "Single"; Break}
+							Default {$tmp = "Session watermark style could not be determined: $($Setting.WatermarkStyle.Value)"; Break}
+						}
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp
+						}
+						$tmp = $Null
+					}
+					If((validStateProp $Setting WatermarkTransparency State ) -and ($Setting.WatermarkTransparency.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Session Watermark\Watermark Style\Watermark transparency"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.WatermarkTransparency.Value;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.WatermarkTransparency.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.WatermarkTransparency.Value 
+						}
+					}
+
 					Write-Verbose "$(Get-Date): `t`t`tICA\Session Reliability"
 					If((validStateProp $Setting SessionReliabilityConnections State ) -and ($Setting.SessionReliabilityConnections.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Session Reliability\Session reliability connections"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SessionReliabilityConnections.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17288,11 +18401,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Session Reliability\Session reliability port number"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SessionReliabilityPort.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17310,11 +18422,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Session Reliability\Session reliability timeout (seconds)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.SessionReliabilityTimeout.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17334,11 +18445,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Time Zone Control\Estimate local time for legacy clients"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LocalTimeEstimation.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17349,6 +18459,28 @@ Function ProcessCitrixPolicies
 						ElseIf($Text)
 						{
 							OutputPolicySetting $txt $Setting.LocalTimeEstimation.State 
+						}
+					}
+					If((validStateProp $Setting RestoreServerTime State ) -and ($Setting.RestoreServerTime.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "ICA\Time Zone Control\Restore Desktop OS time zone on session disconnect or logoff"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.RestoreServerTime.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.RestoreServerTime.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.RestoreServerTime.State 
 						}
 					}
 					If((validStateProp $Setting SessionTimeZone State ) -and ($Setting.SessionTimeZone.State -ne "NotConfigured"))
@@ -17364,11 +18496,10 @@ Function ProcessCitrixPolicies
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17389,11 +18520,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\TWAIN devices\Client TWAIN device redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.TwainRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17411,20 +18541,19 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\TWAIN devices\TWAIN compression level"
 						Switch ($Setting.TwainCompressionLevel.Value)
 						{
-							"None"   {$tmp = "None"; Break}
-							"Low"    {$tmp = "Low"; Break}
-							"Medium" {$tmp = "Medium"; Break}
-							"High"   {$tmp = "High"; Break}
-							Default {$tmp = "TWAIN compression level could not be determined: $($Setting.TwainCompressionLevel.Value)"; Break}
+							"None"		{$tmp = "None"; Break}
+							"Low"		{$tmp = "Low"; Break}
+							"Medium"	{$tmp = "Medium"; Break}
+							"High"		{$tmp = "High"; Break}
+							Default		{$tmp = "TWAIN compression level could not be determined: $($Setting.TwainCompressionLevel.Value)"; Break}
 						}
 
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17439,6 +18568,137 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 
+					Write-Verbose "$(Get-Date): `t`t`tICA\Bidirectional Content Redirection"
+					If((validStateProp $Setting AllowURLRedirection State ) -and ($Setting.AllowURLRedirection.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Bidirectional Content Redirection\Allow Bidirectional Content Redirection"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.AllowURLRedirection.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.AllowURLRedirection.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.AllowURLRedirection.State 
+						}
+					}
+					If((validStateProp $Setting AllowedClientURLs State ) -and ($Setting.AllowedClientURLs.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Bidirectional Content Redirection\Allowed URLs to be redirected to Client"
+						$array = $Setting.AllowedClientURLs.Value.Split(';')
+						$tmp = $array[0]
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+
+						$txt = ""
+						$cnt = -1
+						ForEach($element in $array)
+						{
+							$cnt++
+							
+							If($cnt -ne 0)
+							{
+								$tmp = "$($element) "
+								If($MSWord -or $PDF)
+								{
+									$SettingsWordTable += @{
+									Text = "";
+									Value = $tmp;
+									}
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									"",$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting "" $tmp
+								}
+							}
+						}
+						$array = $Null
+						$tmp = $Null
+					}
+					If((validStateProp $Setting AllowedVDAURLs State ) -and ($Setting.AllowedVDAURLs.State -ne "NotConfigured"))
+					{
+						$txt = "ICA\Bidirectional Content Redirection\Allowed URLs to be redirected to VDA"
+						$array = $Setting.AllowedVDAURLs.Value.Split(';')
+						$tmp = $array[0]
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+
+						$txt = ""
+						$cnt = -1
+						ForEach($element in $array)
+						{
+							$cnt++
+							
+							If($cnt -ne 0)
+							{
+								$tmp = "$($element) "
+								If($MSWord -or $PDF)
+								{
+									$SettingsWordTable += @{
+									Text = "";
+									Value = $tmp;
+									}
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									"",$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting "" $tmp
+								}
+							}
+						}
+						$array = $Null
+						$tmp = $Null
+					}
+
 					Write-Verbose "$(Get-Date): `t`t`tICA\USB Devices"
 					If((validStateProp $Setting ClientUsbDeviceOptimizationRules State ) -and ($Setting.ClientUsbDeviceOptimizationRules.State -ne "NotConfigured"))
 					{
@@ -17449,11 +18709,10 @@ Function ProcessCitrixPolicies
 							$tmp = $array[0]
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -17477,11 +18736,10 @@ Function ProcessCitrixPolicies
 									$tmp = "$($element) "
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -17503,11 +18761,10 @@ Function ProcessCitrixPolicies
 							$tmp = "No Client USB device optimization rules were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -17526,11 +18783,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\USB devices\Client USB device redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.UsbDeviceRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17552,11 +18808,10 @@ Function ProcessCitrixPolicies
 							$tmp = $array[0]
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -17580,11 +18835,10 @@ Function ProcessCitrixPolicies
 									$tmp = "$($element) "
 									If($MSWord -or $PDF)
 									{
-										$WordTableRowHash = @{
+										$SettingsWordTable += @{
 										Text = "";
 										Value = $tmp;
 										}
-										$SettingsWordTable += $WordTableRowHash;
 									}
 									ElseIf($HTML)
 									{
@@ -17606,11 +18860,10 @@ Function ProcessCitrixPolicies
 							$tmp = "No Client USB device redirections rules were found"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -17629,21 +18882,20 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\USB devices\Client USB Plug and Play device redirection"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
-							Value = $Setting.UsbPlugAndPlayRedirection.Value;
+							Value = $Setting.UsbPlugAndPlayRedirection.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
 							$rowdata += @(,(
 							$txt,$htmlbold,
-							$Setting.UsbPlugAndPlayRedirection.Value,$htmlwhite))
+							$Setting.UsbPlugAndPlayRedirection.State,$htmlwhite))
 						}
 						ElseIf($Text)
 						{
-							OutputPolicySetting $txt $Setting.UsbPlugAndPlayRedirection.Value 
+							OutputPolicySetting $txt $Setting.UsbPlugAndPlayRedirection.State 
 						}
 					}
 
@@ -17661,11 +18913,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17683,11 +18934,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Visual Display\Target frame rate (fps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FramesPerSecond.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17715,11 +18965,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17750,11 +18999,10 @@ Function ProcessCitrixPolicies
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17770,14 +19018,13 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting MovingImageCompressionConfiguration State ) -and ($Setting.MovingImageCompressionConfiguration.State -ne "NotConfigured"))
 					{
-						$txt = "ICA\Visual Display\Moving Images\Moving Image Compression"
+						$txt = "ICA\Visual Display\Moving Images\Moving image compression"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MovingImageCompressionConfiguration.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17807,11 +19054,10 @@ Function ProcessCitrixPolicies
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17830,11 +19076,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Visual Display\Moving Images\Progressive compression threshold value (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ProgressiveCompressionThreshold.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17852,11 +19097,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Visual Display\Moving Images\Target Minimum Frame Rate (fps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.TargetedMinimumFramesPerSecond.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17876,11 +19120,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Visual Display\Still Images\Extra Color Compression"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ExtraColorCompression.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17898,11 +19141,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Visual Display\Still Images\Extra Color Compression Threshold (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ExtraColorCompressionThreshold.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17920,11 +19162,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Visual Display\Still Images\Heavyweight compression"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ProgressiveHeavyweightCompression.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17943,20 +19184,19 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.LossyCompressionLevel.Value)
 						{
-							"None"   {$tmp = "None"; Break}
-							"Low"    {$tmp = "Low"; Break}
-							"Medium" {$tmp = "Medium"; Break}
-							"High"   {$tmp = "High"; Break}
-							Default {$tmp = "Lossy compression level could not be determined: $($Setting.LossyCompressionLevel.Value)"; Break}
+							"None"		{$tmp = "None"; Break}
+							"Low"		{$tmp = "Low"; Break}
+							"Medium"	{$tmp = "Medium"; Break}
+							"High"		{$tmp = "High"; Break}
+							Default		{$tmp = "Lossy compression level could not be determined: $($Setting.LossyCompressionLevel.Value)"; Break}
 						}
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17975,11 +19215,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\Visual Display\Still Images\Lossy compression threshold value (Kbps)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LossyCompressionThreshold.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -17999,11 +19238,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\WebSockets\WebSocket connections"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.AcceptWebSocketsConnections.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18021,11 +19259,10 @@ Function ProcessCitrixPolicies
 						$txt = "ICA\WebSockets\WebSockets port number"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.WebSocketsPort.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18052,11 +19289,10 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -18073,16 +19309,15 @@ Function ProcessCitrixPolicies
 							{
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = "";
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
 									$rowdata += @(,(
-									$txt,$htmlbold,
+									"",$htmlbold,
 									$tmp,$htmlwhite))
 								}
 								ElseIf($Text)
@@ -18090,25 +19325,6 @@ Function ProcessCitrixPolicies
 									OutputPolicySetting "" $tmp
 								}
 							}
-						}
-						$tmp = " "
-						If($MSWord -or $PDF)
-						{
-							$WordTableRowHash = @{
-							Text = "";
-							Value = $tmp;
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							$tmp,$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting "" $tmp
 						}
 						$tmpArray = $Null
 						$tmp = $Null
@@ -18122,11 +19338,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.ConcurrentLogonsTolerance.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18143,11 +19358,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.ConcurrentLogonsTolerance.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18184,7 +19398,7 @@ Function ProcessCitrixPolicies
 						{
 							If($Setting.CPUUsage.State -eq "Enabled")
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
@@ -18215,11 +19429,10 @@ Function ProcessCitrixPolicies
 							}
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $tmp;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18236,11 +19449,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.CPUUsageExcludedProcessPriority.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18276,11 +19488,10 @@ Function ProcessCitrixPolicies
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18300,11 +19511,10 @@ Function ProcessCitrixPolicies
 							$txt = "Load Management\Maximum number of sessions - Limit"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.MaximumNumberOfSessions.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18322,11 +19532,10 @@ Function ProcessCitrixPolicies
 							$txt = "Load Management\Maximum number of sessions"
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.MaximumNumberOfSessions.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18362,11 +19571,10 @@ Function ProcessCitrixPolicies
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18394,11 +19602,10 @@ Function ProcessCitrixPolicies
 						
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18414,16 +19621,36 @@ Function ProcessCitrixPolicies
 
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management"
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Advanced settings"
+					If((validStateProp $Setting CEIPEnabled State ) -and ($Setting.CEIPEnabled.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Advanced settings\Customer Experience Improvement Program"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.CEIPEnabled.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.CEIPEnabled.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.CEIPEnabled.State
+						}
+					}
 					If((validStateProp $Setting DisableDynamicConfig State ) -and ($Setting.DisableDynamicConfig.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Advanced settings\Disable automatic configuration"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.DisableDynamicConfig.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18436,16 +19663,37 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.DisableDynamicConfig.State
 						}
 					}
+					If((validStateProp $Setting OutlookSearchRoamingEnabled State ) -and ($Setting.OutlookSearchRoamingEnabled.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "Profile Management\Advanced settings\Enable search index roaming for Outlook"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.OutlookSearchRoamingEnabled.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.OutlookSearchRoamingEnabled.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.OutlookSearchRoamingEnabled.State
+						}
+					}
 					If((validStateProp $Setting LogoffRatherThanTempProfile State ) -and ($Setting.LogoffRatherThanTempProfile.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Advanced settings\Log off user if a problem is encountered"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogoffRatherThanTempProfile.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18463,11 +19711,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Advanced settings\Number of retries when accessing locked files"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LoadRetries_Part.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18480,16 +19727,37 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.LoadRetries_Part.Value 
 						}
 					}
+					If((validStateProp $Setting OutlookEdbBackupEnabled State ) -and ($Setting.OutlookEdbBackupEnabled.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "Profile Management\Advanced settings\Outlook search index database - backup and restore"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.OutlookEdbBackupEnabled.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.OutlookEdbBackupEnabled.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.OutlookEdbBackupEnabled.State
+						}
+					}
 					If((validStateProp $Setting ProcessCookieFiles State ) -and ($Setting.ProcessCookieFiles.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Advanced settings\Process Internet cookie files on logoff"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ProcessCookieFiles.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18509,11 +19777,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Basic settings\Active write back"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.PSMidSessionWriteBack.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18526,16 +19793,36 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.PSMidSessionWriteBack.State
 						}
 					}
+					If((validStateProp $Setting PSMidSessionWriteBackReg State ) -and ($Setting.PSMidSessionWriteBackReg.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Basic settings\Active write back registry"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.PSMidSessionWriteBackReg.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.PSMidSessionWriteBackReg.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.PSMidSessionWriteBack.State
+						}
+					}
 					If((validStateProp $Setting ServiceActive State ) -and ($Setting.ServiceActive.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Basic settings\Enable Profile management"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ServiceActive.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18566,11 +19853,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = $txt;
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -18587,11 +19873,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -18613,11 +19898,10 @@ Function ProcessCitrixPolicies
 								$tmp = "No Excluded groups were found"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -18635,11 +19919,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.ExcludedGroups_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18653,16 +19936,60 @@ Function ProcessCitrixPolicies
 							}
 						}
 					}
+					If((validStateProp $Setting MigrateUserStore_Part State ) -and ($Setting.MigrateUserStore_Part.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "Profile Management\Basic settings\Migrate user store"
+						If($Setting.MigrateUserStore_Part.State -eq "Enabled")
+						{
+							If($MSWord -or $PDF)
+							{
+								$SettingsWordTable += @{
+								Text = $txt;
+								Value = $Setting.MigrateUserStore_Part.Value;
+								}
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.MigrateUserStore_Part.Value,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.MigrateUserStore_Part.Value 
+							}
+						}
+						Else
+						{
+							If($MSWord -or $PDF)
+							{
+								$SettingsWordTable += @{
+								Text = $txt;
+								Value = $Setting.MigrateUserStore_Part.State;
+								}
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.MigrateUserStore_Part.State,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.MigrateUserStore_Part.State
+							}
+						}
+					}
 					If((validStateProp $Setting OfflineSupport State ) -and ($Setting.OfflineSupport.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Basic settings\Offline profile support"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.OfflineSupport.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18682,11 +20009,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.DATPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18703,11 +20029,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.DATPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18726,11 +20051,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Basic settings\Process logons of local administrators"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ProcessAdmins.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18761,11 +20085,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = $txt;
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -18782,11 +20105,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -18808,11 +20130,10 @@ Function ProcessCitrixPolicies
 								$tmp = "No Processed groups were found"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -18830,11 +20151,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.ProcessedGroups_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18848,6 +20168,8 @@ Function ProcessCitrixPolicies
 							}
 						}
 					}
+
+					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Citrix Virtual Apps Optimization settings"
 
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Cross-Platform settings"
 					If((validStateProp $Setting CPUserGroups_Part State ) -and ($Setting.CPUserGroups_Part.State -ne "NotConfigured"))
@@ -18868,11 +20190,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = $txt;
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -18889,11 +20210,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -18915,11 +20235,10 @@ Function ProcessCitrixPolicies
 								$tmp = "No Cross-platform settings user groups were found"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -18937,11 +20256,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.CPUserGroups_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -18960,11 +20278,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Cross-Platform settings\Enable cross-platform settings"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.CPEnable.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -18984,11 +20301,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.CPSchemaPathData.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19005,11 +20321,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.CPSchemaPathData.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19030,11 +20345,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.CPPathData.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19051,11 +20365,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.CPPathData.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19074,11 +20387,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Cross-Platform settings\Source for creating cross-platform settings"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.CPMigrationFromBaseProfileToCPStore.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -19093,6 +20405,690 @@ Function ProcessCitrixPolicies
 					}
 
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\File system"
+					#V1.44
+					If((validStateProp $Setting LogonExclusionCheck_Part State ) -and ($Setting.LogonExclusionCheck_Part.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Logon Exclusion Check"
+						$tmp = ""
+						Switch ($Setting.LogonExclusionCheck_Part.Value)
+						{
+							"Disable"	{$tmp = "Synchronize excluded files or folders"; Break}
+							"Ignore"	{$tmp = "Ignore excluded files or folders"; Break}
+							"Delete"	{$tmp = "Delete excluded files or folders"; Break}
+							Default		{$tmp = "Logon exclusion check could not be determined: $($Setting.LogonExclusionCheck_Part.Value)"; Break}
+						}
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+					}
+					Write-Verbose "$(Get-Date): `t`t`tProfile Management\File system\Default Exclusions"
+					If((validStateProp $Setting DefaultExclusionListSyncDir State ) -and ($Setting.DefaultExclusionListSyncDir.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\Enable Default Exclusion List - directories"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.DefaultExclusionListSyncDir.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.DefaultExclusionListSyncDir.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.DefaultExclusionListSyncDir.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir01 State ) -and ($Setting.ExclusionDefaultDir01.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_internetcache!"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir01.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir01.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir01.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir02 State ) -and ($Setting.ExclusionDefaultDir02.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Google\Chrome\User Data\Default\Cache"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir02.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir02.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir02.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir03 State ) -and ($Setting.ExclusionDefaultDir03.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Google\Chrome\User Data\Default\Cache Theme Images"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir03.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir03.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir03.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir04 State ) -and ($Setting.ExclusionDefaultDir04.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Google\Chrome\User Data\Default\JumpListIcons"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir04.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir04.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir04.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir05 State ) -and ($Setting.ExclusionDefaultDir05.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Google\Chrome\User Data\Default\JumpListIconsOld"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir05.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir05.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir05.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir06 State ) -and ($Setting.ExclusionDefaultDir06.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\GroupPolicy"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir06.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir06.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir06.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir07 State ) -and ($Setting.ExclusionDefaultDir07.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\AppV"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir07.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir07.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir07.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir08 State ) -and ($Setting.ExclusionDefaultDir08.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Messenger"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir08.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir08.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir08.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir09 State ) -and ($Setting.ExclusionDefaultDir09.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Office\15.0\Lync\Tracing"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir09.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir09.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir09.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir10 State ) -and ($Setting.ExclusionDefaultDir10.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\OneNote"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir10.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir10.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir10.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir11 State ) -and ($Setting.ExclusionDefaultDir11.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Outlook"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir11.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir11.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir11.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir12 State ) -and ($Setting.ExclusionDefaultDir12.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Terminal Server Client"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir12.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir12.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir12.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir13 State ) -and ($Setting.ExclusionDefaultDir13.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\UEV"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir13.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir13.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir13.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir14 State ) -and ($Setting.ExclusionDefaultDir14.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Windows Live"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir14.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir14.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir14.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir15 State ) -and ($Setting.ExclusionDefaultDir15.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Windows Live Contacts"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir15.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir15.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir15.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir16 State ) -and ($Setting.ExclusionDefaultDir16.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Windows\Application Shortcuts"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir16.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir16.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir16.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir17 State ) -and ($Setting.ExclusionDefaultDir17.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Windows\Burn"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir17.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir17.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir17.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir18 State ) -and ($Setting.ExclusionDefaultDir18.State -ne "NotConfigured"))
+					{
+						#fixed 3-Mar-2017 thanks to Esther Barthel
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Windows\CD Burning"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir18.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir18.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir18.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir19 State ) -and ($Setting.ExclusionDefaultDir19.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Microsoft\Windows\Notifications"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir19.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir19.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir19.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir20 State ) -and ($Setting.ExclusionDefaultDir20.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Packages"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir20.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir20.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir20.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir21 State ) -and ($Setting.ExclusionDefaultDir21.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Sun"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir21.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir21.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir21.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir22 State ) -and ($Setting.ExclusionDefaultDir22.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localappdata!\Windows Live"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir22.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir22.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir22.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir23 State ) -and ($Setting.ExclusionDefaultDir23.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_localsettings!\Temp"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir23.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir23.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir23.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir24 State ) -and ($Setting.ExclusionDefaultDir24.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_roamingappdata!\Microsoft\AppV\Client\Catalog"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir24.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir24.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir24.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir25 State ) -and ($Setting.ExclusionDefaultDir25.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_roamingappdata!\Sun\Java\Deployment\cache"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir25.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir25.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir25.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir26 State ) -and ($Setting.ExclusionDefaultDir26.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_roamingappdata!\Sun\Java\Deployment\log"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir26.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir26.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir26.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir27 State ) -and ($Setting.ExclusionDefaultDir27.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - !ctx_roamingappdata!\Sun\Java\Deployment\tmp"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir27.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir27.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir27.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir28 State ) -and ($Setting.ExclusionDefaultDir28.State -ne "NotConfigured"))
+					{
+						$txt = 'Profile Management\File system\Default Exclusions\UPM - $Recycle.Bin'
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir28.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir28.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir28.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir29 State ) -and ($Setting.ExclusionDefaultDir29.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - AppData\LocalLow"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir29.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir29.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir29.State
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultDir30 State ) -and ($Setting.ExclusionDefaultDir30.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Default Exclusions\UPM - Tracing"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultDir30.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultDir30.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultDir30.State
+						}
+					}
+					
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\File system\Exclusions"
 					If((validStateProp $Setting ExclusionListSyncDir_Part State ) -and ($Setting.ExclusionListSyncDir_Part.State -ne "NotConfigured"))
 					{
@@ -19112,11 +21108,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = $txt;
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19133,11 +21128,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19159,11 +21153,10 @@ Function ProcessCitrixPolicies
 								$tmp = "No Exclusion list - directories were found"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -19181,11 +21174,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.ExclusionListSyncDir_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19217,11 +21209,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = $txt;
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19238,11 +21229,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19264,11 +21254,10 @@ Function ProcessCitrixPolicies
 								$tmp = "No Exclusion list - files were found"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -19286,11 +21275,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.ExclusionListSyncFiles_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19324,11 +21312,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = $txt;
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19345,11 +21332,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19371,11 +21357,10 @@ Function ProcessCitrixPolicies
 								$tmp = "No Directories to synchronize were found"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -19393,11 +21378,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.SyncDirList_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19429,11 +21413,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = $txt;
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19450,11 +21433,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19476,11 +21458,10 @@ Function ProcessCitrixPolicies
 								$tmp = "No Files to synchronize were found"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -19498,11 +21479,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.SyncFileList_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19534,11 +21514,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = $txt;
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19555,11 +21534,10 @@ Function ProcessCitrixPolicies
 									{
 										If($MSWord -or $PDF)
 										{
-											$WordTableRowHash = @{
+											$SettingsWordTable += @{
 											Text = "";
 											Value = $tmp;
 											}
-											$SettingsWordTable += $WordTableRowHash;
 										}
 										ElseIf($HTML)
 										{
@@ -19581,11 +21559,10 @@ Function ProcessCitrixPolicies
 								$tmp = "No Folders to mirror were found"
 								If($MSWord -or $PDF)
 								{
-									$WordTableRowHash = @{
+									$SettingsWordTable += @{
 									Text = $txt;
 									Value = $tmp;
 									}
-									$SettingsWordTable += $WordTableRowHash;
 								}
 								ElseIf($HTML)
 								{
@@ -19603,11 +21580,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.MirrorFoldersList_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19621,6 +21597,107 @@ Function ProcessCitrixPolicies
 							}
 						}
 					}
+					If((validStateProp $Setting ProfileContainer_Part State ) -and ($Setting.ProfileContainer_Part.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\File system\Synchronization\Profile container - List of folders to be contained in profile disk"
+						If($Setting.ProfileContainer_Part.State -eq "Enabled")
+						{
+							If(validStateProp $Setting ProfileContainer_Part Values )
+							{
+								$tmpArray = $Setting.ProfileContainer_Part.Values
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
+								{
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
+									{
+										If($MSWord -or $PDF)
+										{
+											$SettingsWordTable += @{
+											Text = $txt;
+											Value = $tmp;
+											}
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
+									}
+									Else
+									{
+										If($MSWord -or $PDF)
+										{
+											$SettingsWordTable += @{
+											Text = "";
+											Value = $tmp;
+											}
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
+									}
+								}
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Directories to synchronize were found"
+								If($MSWord -or $PDF)
+								{
+									$SettingsWordTable += @{
+									Text = $txt;
+									Value = $tmp;
+									}
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
+								}
+							}
+						}
+						Else
+						{
+							If($MSWord -or $PDF)
+							{
+								$SettingsWordTable += @{
+								Text = $txt;
+								Value = $Setting.ProfileContainer_Part.State;
+								}
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.ProfileContainer_Part.State,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.ProfileContainer_Part.State
+							}
+						}
+					}
 
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection"
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\AppData(Roaming)"
@@ -19631,11 +21708,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRAppDataPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19652,11 +21728,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRAppDataPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19677,16 +21752,14 @@ Function ProcessCitrixPolicies
 						Switch ($Setting.FRAppData_Part.Value)
 						{
 							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRAppData_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -19706,11 +21779,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Folder Redirection\Common settings\Grant administrator access"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FRAdminAccess_Part.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -19728,11 +21800,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Folder Redirection\Common settings\Include domain name"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.FRIncDomainName_Part.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -19754,11 +21825,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRContactsPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19775,11 +21845,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRContactsPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19799,17 +21868,15 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.FRContacts_Part.Value)
 						{
-							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
+							"RedirectUncPath"	{$tmp = "Redirect to the following UNC path"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRContacts_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -19831,11 +21898,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRDesktopPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19852,11 +21918,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRDesktopPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19876,17 +21941,15 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.FRDesktop_Part.Value)
 						{
-							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
+							"RedirectUncPath"	{$tmp = "Redirect to the following UNC path"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRDesktop_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -19908,11 +21971,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRDocumentsPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19929,11 +21991,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRDocumentsPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -19953,17 +22014,16 @@ Function ProcessCitrixPolicies
 						$tmp = ""
 						Switch ($Setting.FRDocuments_Part.Value)
 						{
-							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
+							"RedirectUncPath"		{$tmp = "Redirect to the following UNC path"; Break}
+							"RedirectRelativeHome"	{$tmp = "Redirect to the users' home directory"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRDocuments_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -19985,11 +22045,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRDownloadsPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20006,11 +22065,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRDownloadsPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20031,16 +22089,14 @@ Function ProcessCitrixPolicies
 						Switch ($Setting.FRDownloads_Part.Value)
 						{
 							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRDownloads_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20062,11 +22118,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRFavoritesPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20083,11 +22138,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRFavoritesPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20108,16 +22162,14 @@ Function ProcessCitrixPolicies
 						Switch ($Setting.FRFavorites_Part.Value)
 						{
 							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRFavorites_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20139,11 +22191,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRLinksPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20160,11 +22211,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRLinksPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20185,16 +22235,14 @@ Function ProcessCitrixPolicies
 						Switch ($Setting.FRLinks_Part.Value)
 						{
 							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
 							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRLinks_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20216,11 +22264,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRMusicPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20237,11 +22284,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRMusicPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20267,11 +22313,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20293,11 +22338,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRPicturesPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20314,11 +22358,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRPicturesPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20344,11 +22387,10 @@ Function ProcessCitrixPolicies
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20363,6 +22405,33 @@ Function ProcessCitrixPolicies
 					}
 
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Saved Games"
+					If((validStateProp $Setting FRSavedGames_Part State ) -and ($Setting.FRSavedGames_Part.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Folder Redirection\Saved Games\Redirection settings for Saved Games"
+						$tmp = ""
+						Switch ($Setting.FRSavedGames_Part.Value)
+						{
+							"RedirectUncPath"	{$tmp = "Redirect to the following UNC path"; Break}
+							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRSavedGames_Part.Value)"; Break}
+						}
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $tmp;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp 
+						}
+					}
 					If((validStateProp $Setting FRSavedGamesPath_Part State ) -and ($Setting.FRSavedGamesPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Saved Games\Saved Games path"
@@ -20370,11 +22439,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRSavedGamesPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20391,11 +22459,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRSavedGamesPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20409,23 +22476,23 @@ Function ProcessCitrixPolicies
 							}
 						}
 					}
-					If((validStateProp $Setting FRSavedGames_Part State ) -and ($Setting.FRSavedGames_Part.State -ne "NotConfigured"))
+
+					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Searches"
+					If((validStateProp $Setting FRSearches_Part State ) -and ($Setting.FRSearches_Part.State -ne "NotConfigured"))
 					{
-						$txt = "Profile Management\Folder Redirection\Saved Games\Redirection settings for Saved Games"
+						$txt = "Profile Management\Folder Redirection\Searches\Redirection settings for Searches"
 						$tmp = ""
-						Switch ($Setting.FRSavedGames_Part.Value)
+						Switch ($Setting.FRSearches_Part.Value)
 						{
-							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
-							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRSavedGames_Part.Value)"; Break}
+							"RedirectUncPath"	{$tmp = "Redirect to the following UNC path"; Break}
+							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRSearches_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20438,8 +22505,6 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $tmp 
 						}
 					}
-
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Searches"
 					If((validStateProp $Setting FRSearchesPath_Part State ) -and ($Setting.FRSearchesPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Searches\Searches path"
@@ -20447,11 +22512,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRSearchesPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20468,11 +22532,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRSearchesPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20486,23 +22549,23 @@ Function ProcessCitrixPolicies
 							}
 						}
 					}
-					If((validStateProp $Setting FRSearches_Part State ) -and ($Setting.FRSearches_Part.State -ne "NotConfigured"))
+
+					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Start Menu"
+					If((validStateProp $Setting FRStartMenu_Part State ) -and ($Setting.FRStartMenu_Part.State -ne "NotConfigured"))
 					{
-						$txt = "Profile Management\Folder Redirection\Searches\Redirection settings for Searches"
+						$txt = "Profile Management\Folder Redirection\Start Menu\Redirection settings for Start Menu"
 						$tmp = ""
-						Switch ($Setting.FRSearches_Part.Value)
+						Switch ($Setting.FRStartMenu_Part.Value)
 						{
-							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
-							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRSearches_Part.Value)"; Break}
+							"RedirectUncPath"	{$tmp = "Redirect to the following UNC path"; Break}
+							Default 			{$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRStartMenu_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20515,8 +22578,6 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $tmp 
 						}
 					}
-
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Start Menu"
 					If((validStateProp $Setting FRStartMenuPath_Part State ) -and ($Setting.FRStartMenuPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Start Menu\Start Menu path"
@@ -20524,11 +22585,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRStartMenuPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20545,11 +22605,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRStartMenuPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20563,23 +22622,24 @@ Function ProcessCitrixPolicies
 							}
 						}
 					}
-					If((validStateProp $Setting FRStartMenu_Part State ) -and ($Setting.FRStartMenu_Part.State -ne "NotConfigured"))
+
+					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Videos"
+					If((validStateProp $Setting FRVideos_Part State ) -and ($Setting.FRVideos_Part.State -ne "NotConfigured"))
 					{
-						$txt = "Profile Management\Folder Redirection\Start Menu\Redirection settings for Start Menu"
+						$txt = "Profile Management\Folder Redirection\Videos\Redirection settings for Videos"
 						$tmp = ""
-						Switch ($Setting.FRStartMenu_Part.Value)
+						Switch ($Setting.FRVideos_Part.Value)
 						{
 							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
 							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
-							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRStartMenu_Part.Value)"; Break}
+							Default 					{$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRVideos_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20592,8 +22652,6 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $tmp 
 						}
 					}
-
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Videos"
 					If((validStateProp $Setting FRVideosPath_Part State ) -and ($Setting.FRVideosPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Videos\Videos path"
@@ -20601,11 +22659,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRVideosPath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20622,11 +22679,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.FRVideosPath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20640,35 +22696,6 @@ Function ProcessCitrixPolicies
 							}
 						}
 					}
-					If((validStateProp $Setting FRVideos_Part State ) -and ($Setting.FRVideos_Part.State -ne "NotConfigured"))
-					{
-						$txt = "Profile Management\Folder Redirection\Videos\Redirection settings for Videos"
-						$tmp = ""
-						Switch ($Setting.FRVideos_Part.Value)
-						{
-							"RedirectUncPath"			{$tmp = "Redirect to the following UNC path"; Break}
-							"RedirectRelativeDocuments" {$tmp = "Redirect relative to Documents folder"; Break}
-							Default {$tmp = "AppData(Roaming) path cannot be determined: $($Setting.FRVideos_Part.Value)"; Break}
-						}
-						If($MSWord -or $PDF)
-						{
-							$WordTableRowHash = @{
-							Text = $txt;
-							Value = $tmp;
-							}
-							$SettingsWordTable += $WordTableRowHash;
-						}
-						ElseIf($HTML)
-						{
-							$rowdata += @(,(
-							$txt,$htmlbold,
-							$tmp,$htmlwhite))
-						}
-						ElseIf($Text)
-						{
-							OutputPolicySetting $txt $tmp 
-						}
-					}
 
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Log settings"
 					If((validStateProp $Setting LogLevel_ActiveDirectoryActions State ) -and ($Setting.LogLevel_ActiveDirectoryActions.State -ne "NotConfigured"))
@@ -20676,11 +22703,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Active Directory actions"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_ActiveDirectoryActions.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20698,11 +22724,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Common information"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_Information.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20720,11 +22745,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Common warnings"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_Warnings.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20742,11 +22766,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Enable logging"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.DebugMode.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20764,11 +22787,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\File system actions"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_FileSystemActions.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20786,11 +22808,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\File system notifications"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_FileSystemNotification.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20808,11 +22829,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Logoff"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_Logoff.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20830,11 +22850,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Logon"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_Logon.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20852,11 +22871,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Maximum size of the log file (bytes)"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.MaxLogSize_Part.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20876,11 +22894,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.DebugFilePath_Part.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20897,11 +22914,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.DebugFilePath_Part.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -20920,11 +22936,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Personalized user information"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_UserName.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20942,11 +22957,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Policy values at logon and logoff"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_PolicyUserLogon.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20964,11 +22978,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Registry actions"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_RegistryActions.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -20986,11 +22999,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Log settings\Registry differences at logoff"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.LogLevel_RegistryDifference.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -21005,16 +23017,37 @@ Function ProcessCitrixPolicies
 					}
 
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Profile handling"
+					If((validStateProp $Setting ApplicationProfilesAutoMigration State ) -and ($Setting.ApplicationProfilesAutoMigration.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "Profile Management\Profile handling\Automatic migration of existing application profiles"
+						If($MSWord -or $PDF)
+						{
+							$SettingsWordTable += @{
+							Text = $txt;
+							Value = $Setting.ApplicationProfilesAutoMigration.State;
+							}
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ApplicationProfilesAutoMigration.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ApplicationProfilesAutoMigration.State
+						}
+					}
 					If((validStateProp $Setting ProfileDeleteDelay_Part State ) -and ($Setting.ProfileDeleteDelay_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Profile handling\Delay before deleting cached profiles"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.ProfileDeleteDelay_Part.Value;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -21032,11 +23065,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Profile handling\Delete locally cached profiles on logoff"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.DeleteCachedProfilesOnLogoff.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -21058,15 +23090,14 @@ Function ProcessCitrixPolicies
 							"Use"		{$tmp = "Use local profile"; Break}
 							"Delete"	{$tmp = "Delete local profile"; Break}
 							"Rename"	{$tmp = "Rename local profile"; Break}
-							Default	{$tmp = "Local profile conflict handling could not be determined: $($Setting.LocalProfileConflictHandling_Part.Value)"; Break}
+							Default		{$tmp = "Local profile conflict handling could not be determined: $($Setting.LocalProfileConflictHandling_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -21089,15 +23120,14 @@ Function ProcessCitrixPolicies
 							"Local"		{$tmp = "Local"; Break}
 							"Roaming"	{$tmp = "Roaming"; Break}
 							"None"		{$tmp = "None"; Break}
-							Default	{$tmp = "Migration of existing profiles could not be determined: $($Setting.MigrateWindowsProfilesToUserStore_Part.Value)"; Break}
+							Default		{$tmp = "Migration of existing profiles could not be determined: $($Setting.MigrateWindowsProfilesToUserStore_Part.Value)"; Break}
 						}
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $tmp;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -21117,11 +23147,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.TemplateProfilePath.Value;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -21138,11 +23167,10 @@ Function ProcessCitrixPolicies
 						{
 							If($MSWord -or $PDF)
 							{
-								$WordTableRowHash = @{
+								$SettingsWordTable += @{
 								Text = $txt;
 								Value = $Setting.TemplateProfilePath.State;
 								}
-								$SettingsWordTable += $WordTableRowHash;
 							}
 							ElseIf($HTML)
 							{
@@ -21161,11 +23189,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Profile handling\Template profile overrides local profile"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.TemplateProfileOverridesLocalProfile.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -21183,11 +23210,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Profile handling\Template profile overrides roaming profile"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.TemplateProfileOverridesRoamingProfile.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -21205,11 +23231,10 @@ Function ProcessCitrixPolicies
 						$txt = "Profile Management\Profile handling\Template profile used as a Citrix mandatory profile for all logons"
 						If($MSWord -or $PDF)
 						{
-							$WordTableRowHash = @{
+							$SettingsWordTable += @{
 							Text = $txt;
 							Value = $Setting.TemplateProfileIsMandatory.State;
 							}
-							$SettingsWordTable += $WordTableRowHash;
 						}
 						ElseIf($HTML)
 						{
@@ -21434,6 +23459,118 @@ Function ProcessCitrixPolicies
 							}
 						}
 					}
+					If((validStateProp $Setting LastKnownGoodRegistry State ) -and ($Setting.LastKnownGoodRegistry.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Registry\NTUSER.DAT backup"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.LastKnownGoodRegistry.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.LastKnownGoodRegistry.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.LastKnownGoodRegistry.State 
+						}
+					}
+
+					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Registry\Default Exclusions"
+					If((validStateProp $Setting DefaultExclusionList State ) -and ($Setting.DefaultExclusionList.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Registry\Enable Default Exclusion list"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.DefaultExclusionList.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.DefaultExclusionList.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.DefaultExclusionList.State 
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultReg01 State ) -and ($Setting.ExclusionDefaultReg01.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Registry\UPM - Software\Microsoft\AppV\Client\Integration"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultReg01.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultReg01.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultReg01.State 
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultReg02 State ) -and ($Setting.ExclusionDefaultReg02.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Registry\UPM - Software\Microsoft\AppV\Client\Publishing"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultReg02.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultReg02.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultReg02.State 
+						}
+					}
+					If((validStateProp $Setting ExclusionDefaultReg03 State ) -and ($Setting.ExclusionDefaultReg03.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Registry\UPM - Software\Microsoft\Speech_OneCore"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ExclusionDefaultReg03.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ExclusionDefaultReg03.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ExclusionDefaultReg03.State 
+						}
+					}
 
 					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Streamed user profiles"
 					If((validStateProp $Setting PSAlwaysCache State ) -and ($Setting.PSAlwaysCache.State -ne "NotConfigured"))
@@ -21524,6 +23661,111 @@ Function ProcessCitrixPolicies
 						ElseIf($Text)
 						{
 							OutputPolicySetting $txt $Setting.PSEnabled.State 
+						}
+					}
+					If((validStateProp $Setting StreamingExclusionList_Part State ) -and ($Setting.StreamingExclusionList_Part.State -ne "NotConfigured"))
+					{
+						$txt = "Profile Management\Streamed user profiles\Profile Streaming Exclusion list - directories"
+						If($Setting.StreamingExclusionList_Part.State -eq "Enabled")
+						{
+							If(validStateProp $Setting StreamingExclusionList_Part Values )
+							{
+								$tmpArray = $Setting.StreamingExclusionList_Part.Values.Split(",")
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
+								{
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
+									{
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
+									}
+									Else
+									{
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "`t`t`t`t`t`t`t`t`t`t`t" $tmp
+										}
+									}
+								}
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No Profile Streaming Exclusion list - directories were found"
+								If($MSWord -or $PDF)
+								{
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
+									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
+								}
+							}
+						}
+						Else
+						{
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $Setting.StreamingExclusionList_Part.State;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.StreamingExclusionList_Part.State,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.StreamingExclusionList_Part.State 
+							}
 						}
 					}
 					If((validStateProp $Setting PSUserGroups_Part State ) -and ($Setting.PSUserGroups_Part.State -ne "NotConfigured"))
@@ -21653,6 +23895,77 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.PSPendingLockTimeout.Value 
 						}
 					}
+					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Citrix Virtual Apps Optimization settings"
+					If((validStateProp $Setting XenAppOptimizationEnable State ) -and ($Setting.XenAppOptimizationEnable.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "Profile Management\Citrix Virtual Apps Optimization settings\Enable Citrix Virtual Apps Optimization"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.XenAppOptimizationEnable.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.XenAppOptimizationEnable.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.XenAppOptimizationEnable.State
+						}
+					}
+					If((validStateProp $Setting XenAppOptimizationDefinitionPathData State ) -and ($Setting.XenAppOptimizationDefinitionPathData.State -ne "NotConfigured"))
+					{
+						#V1.44
+						$txt = "Profile Management\Citrix Virtual Apps Optimization settings\Path to Citrix Virtual Apps optimization definitions:"
+						If($Setting.XenAppOptimizationDefinitionPathData.State -eq "Enabled")
+						{
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $Setting.XenAppOptimizationDefinitionPathData.Value;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.XenAppOptimizationDefinitionPathData.Value,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.XenAppOptimizationDefinitionPathData.Value 
+							}
+						}
+						Else
+						{
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $Setting.XenAppOptimizationDefinitionPathData.State;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.XenAppOptimizationDefinitionPathData.State,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.XenAppOptimizationDefinitionPathData.State 
+							}
+						}
+					}
 
 					Write-Verbose "$(Get-Date): `t`t`tReceiver"
 					If((validStateProp $Setting StorefrontAccountsList State ) -and ($Setting.StorefrontAccountsList.State -ne "NotConfigured"))
@@ -21679,16 +23992,17 @@ Function ProcessCitrixPolicies
 						$txt = ""
 						If(validStateProp $Setting StorefrontAccountsList Values )
 						{
+							$cnt = 0
 							$tmpArray = $Setting.StorefrontAccountsList.Values
 							ForEach($Thing in $TmpArray)
 							{
 								$cnt++
 								$xxx = """$($Thing)"""
 								[array]$tmp = $xxx.Split(";").replace('"','')
-								$tmp1 = "Name: $($tmp[0])"
-								$tmp2 = "URL: $($tmp[1])"
+								$tmp1 = "Name : $($tmp[0])"
+								$tmp2 = "URL  : $($tmp[1])"
 								$tmp3 = "State: $($tmp[2])"
-								$tmp4 = "Desc: $($tmp[3])"
+								$tmp4 = "Desc : $($tmp[3])"
 								If($MSWord -or $PDF)
 								{
 									$WordTableRowHash = @{
@@ -21735,29 +24049,34 @@ Function ProcessCitrixPolicies
 								}
 								ElseIf($Text)
 								{
+									$txt = "`t`t`t`t "
 									OutputPolicySetting $txt $tmp1
 									OutputPolicySetting $txt $tmp2
 									OutputPolicySetting $txt $tmp3
 									OutputPolicySetting $txt $tmp4
 								}
-								$tmp = " "
-								If($MSWord -or $PDF)
+								
+								If($cnt -gt 1)
 								{
-									$WordTableRowHash = @{
-									Text = "";
-									Value = $tmp;
+									$tmp = " "
+									If($MSWord -or $PDF)
+									{
+										$WordTableRowHash = @{
+										Text = "";
+										Value = $tmp;
+										}
+										$SettingsWordTable += $WordTableRowHash;
 									}
-									$SettingsWordTable += $WordTableRowHash;
-								}
-								ElseIf($HTML)
-								{
-									$rowdata += @(,(
-									"",$htmlbold,
-									"",$htmlwhite))
-								}
-								ElseIf($Text)
-								{
-									OutputPolicySetting "" $tmp
+									ElseIf($HTML)
+									{
+										$rowdata += @(,(
+										"",$htmlbold,
+										"",$htmlwhite))
+									}
+									ElseIf($Text)
+									{
+										OutputPolicySetting "" $tmp
+									}
 								}
 								$xxx = $Null
 								$tmp = $Null
@@ -21794,9 +24113,33 @@ Function ProcessCitrixPolicies
 					}
 
 					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings"
+					If((validStateProp $Setting ControllerRegistrationIPv6Netmask State ) -and ($Setting.ControllerRegistrationIPv6Netmask.State -ne "NotConfigured"))
+					{
+						#AD specific setting
+						$txt = "Virtual Delivery Agent Settings\Controller registration IPv6 netmask"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.ControllerRegistrationIPv6Netmask.Value;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.ControllerRegistrationIPv6Netmask.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.ControllerRegistrationIPv6Netmask.Value 
+						}
+					}
 					If((validStateProp $Setting ControllerRegistrationPort State ) -and ($Setting.ControllerRegistrationPort.State -ne "NotConfigured"))
 					{
-						$txt = "Virtual Delivery Agent Settings\Controller Registration Port"
+						#AD specific setting
+						$txt = "Virtual Delivery Agent Settings\Controller registration port"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
@@ -21818,6 +24161,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting ControllerSIDs State ) -and ($Setting.ControllerSIDs.State -ne "NotConfigured"))
 					{
+						#AD specific setting
 						$txt = "Virtual Delivery Agent Settings\Controller SIDs"
 						If($MSWord -or $PDF)
 						{
@@ -21840,6 +24184,7 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting Controllers State ) -and ($Setting.Controllers.State -ne "NotConfigured"))
 					{
+						#AD specific setting
 						$txt = "Virtual Delivery Agent Settings\Controllers"
 						If($MSWord -or $PDF)
 						{
@@ -21860,14 +24205,14 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.Controllers.Value 
 						}
 					}
-					If((validStateProp $Setting SiteGUID State ) -and ($Setting.SiteGUID.State -ne "NotConfigured"))
+					If((validStateProp $Setting EnableAutoUpdateOfControllers State ) -and ($Setting.EnableAutoUpdateOfControllers.State -ne "NotConfigured"))
 					{
-						$txt = "Virtual Delivery Agent Settings\Site GUID"
+						$txt = "Virtual Delivery Agent Settings\Enable auto update of Controllers"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
 							Text = $txt;
-							Value = $Setting.SiteGUID.Value;
+							Value = $Setting.EnableAutoUpdateOfControllers.State;
 							}
 							$SettingsWordTable += $WordTableRowHash;
 						}
@@ -21875,14 +24220,14 @@ Function ProcessCitrixPolicies
 						{
 							$rowdata += @(,(
 							$txt,$htmlbold,
-							$Setting.SiteGUID.Value,$htmlwhite))
+							$Setting.EnableAutoUpdateOfControllers.State,$htmlwhite))
 						}
 						ElseIf($Text)
 						{
-							OutputPolicySetting $txt $Setting.SiteGUID.Value 
+							OutputPolicySetting $txt $Setting.EnableAutoUpdateOfControllers.State 
 						}
 					}
-
+					
 					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\CPU Usage Monitoring"
 					If((validStateProp $Setting CPUUsageMonitoring_Enable State ) -and ($Setting.CPUUsageMonitoring_Enable.State -ne "NotConfigured"))
 					{
@@ -21954,7 +24299,7 @@ Function ProcessCitrixPolicies
 					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\HDX3DPro"
 					If((validStateProp $Setting EnableLossless State ) -and ($Setting.EnableLossless.State -ne "NotConfigured"))
 					{
-						$txt = "Virtual Delivery Agent Settings\HDX3DPro\EnableLossless"
+						$txt = "Virtual Delivery Agent Settings\HDX3DPro\Enable lossless"
 						If($MSWord -or $PDF)
 						{
 							$WordTableRowHash = @{
@@ -21976,11 +24321,11 @@ Function ProcessCitrixPolicies
 					}
 					If((validStateProp $Setting ProGraphicsObj State ) -and ($Setting.ProGraphicsObj.State -ne "NotConfigured"))
 					{
-						$txt = "Virtual Delivery Agent Settings\HDX3DPro\HDX3DPro Quality Settings"
+						$txt = "Virtual Delivery Agent Settings\HDX3DPro\HDX3DPro quality settings"
 						$tmp = ""
 						$xMin = [math]::floor($Setting.ProGraphicsObj.Value%65536).ToString()
 						$xMax = [math]::floor($Setting.ProGraphicsObj.Value/65536).ToString()
-						$tmp = "Minimum: $($xMin) Maximum: $($xMax)"
+						[string]$tmp = "Minimum: $($xMin) Maximum: $($xMax)"
 						
 						If($MSWord -or $PDF)
 						{
@@ -22071,6 +24416,256 @@ Function ProcessCitrixPolicies
 						}
 					}
 
+					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\Monitoring"
+					If((validStateProp $Setting SelectedFailureLevel State ) -and ($Setting.SelectedFailureLevel.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Monitoring\Enable monitoring of application failures"
+						$tmp = ""
+						Switch ($Setting.SelectedFailureLevel.Value)
+						{
+							"None"	{$tmp = "None"; Break}
+							"Both"	{$tmp = "Both application errors and faults"; Break}
+							"Fault"	{$tmp = "Application faults only"; Break}
+							"Error"	{$tmp = "Application errors only"; Break}
+							Default	{$tmp = "Enable monitoring of application failures could not be determined: $($Setting.SelectedFailureLevel.Value)"; Break}
+						}
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $tmp;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$tmp,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $tmp
+						}
+					}
+					If((validStateProp $Setting EnableWorkstationVDAFaultMonitoring State ) -and ($Setting.EnableWorkstationVDAFaultMonitoring.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Monitoring\Enable monitoring of application failures on Desktop OS VDAs"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.EnableWorkstationVDAFaultMonitoring.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.EnableWorkstationVDAFaultMonitoring.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.EnableWorkstationVDAFaultMonitoring.State 
+						}
+					}
+					If((validStateProp $Setting EnableProcessMonitoring State ) -and ($Setting.EnableProcessMonitoring.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Monitoring\Enable process monitoring"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.EnableProcessMonitoring.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.EnableProcessMonitoring.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.EnableProcessMonitoring.State 
+						}
+					}
+					If((validStateProp $Setting EnableResourceMonitoring State ) -and ($Setting.EnableResourceMonitoring.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Monitoring\Enable resource monitoring"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.EnableResourceMonitoring.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.EnableResourceMonitoring.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.EnableResourceMonitoring.State 
+						}
+					}
+					If((validStateProp $Setting AppFailureExclusionList State ) -and ($Setting.AppFailureExclusionList.State -ne "NotConfigured"))
+					{
+						$txt = "Virtual Delivery Agent Settings\Monitoring\List of applications excluded from failure monitoring"
+						If($Setting.StreamingExclusionList_Part.State -eq "Enabled")
+						{
+							If(validStateProp $Setting AppFailureExclusionList Values )
+							{
+								$tmpArray = $Setting.AppFailureExclusionList.Values.Split(",")
+								$tmp = ""
+								$cnt = 0
+								ForEach($Thing in $tmpArray)
+								{
+									$cnt++
+									$tmp = "$($Thing)"
+									If($cnt -eq 1)
+									{
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = $txt;
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											$txt,$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting $txt $tmp
+										}
+									}
+									Else
+									{
+										If($MSWord -or $PDF)
+										{
+											$WordTableRowHash = @{
+											Text = "";
+											Value = $tmp;
+											}
+											$SettingsWordTable += $WordTableRowHash;
+										}
+										ElseIf($HTML)
+										{
+											$rowdata += @(,(
+											"",$htmlbold,
+											$tmp,$htmlwhite))
+										}
+										ElseIf($Text)
+										{
+											OutputPolicySetting "" $tmp
+										}
+									}
+								}
+								$tmpArray = $Null
+								$tmp = $Null
+							}
+							Else
+							{
+								$tmp = "No List of applications excluded from failure monitoring were found"
+								If($MSWord -or $PDF)
+								{
+									$WordTableRowHash = @{
+									Text = $txt;
+									Value = $tmp;
+									}
+									$SettingsWordTable += $WordTableRowHash;
+								}
+								ElseIf($HTML)
+								{
+									$rowdata += @(,(
+									$txt,$htmlbold,
+									$tmp,$htmlwhite))
+								}
+								ElseIf($Text)
+								{
+									OutputPolicySetting $txt $tmp
+								}
+							}
+						}
+						Else
+						{
+							If($MSWord -or $PDF)
+							{
+								$WordTableRowHash = @{
+								Text = $txt;
+								Value = $Setting.AppFailureExclusionList.State;
+								}
+								$SettingsWordTable += $WordTableRowHash;
+							}
+							ElseIf($HTML)
+							{
+								$rowdata += @(,(
+								$txt,$htmlbold,
+								$Setting.AppFailureExclusionList.State,$htmlwhite))
+							}
+							ElseIf($Text)
+							{
+								OutputPolicySetting $txt $Setting.AppFailureExclusionList.State 
+							}
+						}
+					}	
+					If((validStateProp $Setting OnlyUseIPv6ControllerRegistration State ) -and ($Setting.OnlyUseIPv6ControllerRegistration.State -ne "NotConfigured"))
+					{
+						#AD specific setting
+						$txt = "Virtual Delivery Agent Settings\Only use IPv6 Controller registration"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.OnlyUseIPv6ControllerRegistration.State;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.OnlyUseIPv6ControllerRegistration.State,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.OnlyUseIPv6ControllerRegistration.State 
+						}
+					}
+					If((validStateProp $Setting SiteGUID State ) -and ($Setting.SiteGUID.State -ne "NotConfigured"))
+					{
+						#AD specific setting
+						$txt = "Virtual Delivery Agent Settings\Site GUID"
+						If($MSWord -or $PDF)
+						{
+							$WordTableRowHash = @{
+							Text = $txt;
+							Value = $Setting.SiteGUID.Value;
+							}
+							$SettingsWordTable += $WordTableRowHash;
+						}
+						ElseIf($HTML)
+						{
+							$rowdata += @(,(
+							$txt,$htmlbold,
+							$Setting.SiteGUID.Value,$htmlwhite))
+						}
+						ElseIf($Text)
+						{
+							OutputPolicySetting $txt $Setting.SiteGUID.Value 
+						}
+					}
+					
 					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\Profile Load Time Monitoring"
 					If((validStateProp $Setting ProfileLoadTimeMonitoring_Enable State ) -and ($Setting.ProfileLoadTimeMonitoring_Enable.State -ne "NotConfigured"))
 					{
@@ -22116,7 +24711,7 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.ProfileLoadTimeMonitoring_Threshold.Value 
 						}
 					}
-					
+
 					Write-Verbose "$(Get-Date): `t`t`tVirtual IP"
 					If((validStateProp $Setting VirtualLoopbackSupport State ) -and ($Setting.VirtualLoopbackSupport.State -ne "NotConfigured"))
 					{
@@ -22229,22 +24824,29 @@ Function ProcessCitrixPolicies
 				}
 				If($MSWord -or $PDF)
 				{
-					$Table = AddWordTable -Hashtable $SettingsWordTable `
-					-Columns  Text,Value `
-					-Headers  "Setting Key","Value"`
-					-Format $wdTableLightListAccent3 `
-					-NoInternalGridLines `
-					-AutoFit $wdAutoFitFixed;
+					If($SettingsWordTable.Count -gt 0) #V1.44 don't process if array is empty
+					{
+						$Table = AddWordTable -Hashtable $SettingsWordTable `
+						-Columns  Text,Value `
+						-Headers  "Setting Key","Value"`
+						-Format $wdTableLightListAccent3 `
+						-NoInternalGridLines `
+						-AutoFit $wdAutoFitFixed;
 
-					SetWordCellFormat -Collection $Table -Size 9
-					
-					SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
+						SetWordCellFormat -Collection $Table -Size 9
+						
+						SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
-					$Table.Columns.Item(1).Width = 300;
-					$Table.Columns.Item(2).Width = 200;
+						$Table.Columns.Item(1).Width = 300;
+						$Table.Columns.Item(2).Width = 200;
 
-					$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
-
+						$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustProportional)
+					}
+					Else
+					{
+						#V1.44 state there are no policy settings
+						WriteWordLine 0 1 "There are no policy settings"
+					}
 					FindWordDocumentEnd
 					$Table = $Null
 				}
@@ -22257,8 +24859,8 @@ Function ProcessCitrixPolicies
 					If($rowdata.count -gt 0)
 					{
 						$columnHeaders = @(
-						'Setting Key',($htmlsilver -bor $htmlbold),
-						'Value',($htmlsilver -bor $htmlbold))
+						'Setting Key',($global:htmlsb),
+						'Value',($global:htmlsb))
 
 						$msg = ""
 						$columnWidths = @("400","300")
@@ -22835,7 +25437,7 @@ Function OutputConfigLogPreferences
 	
 	If($MSWord -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $ItemsWordTable = @();
+		[System.Collections.Hashtable[]] $ScriptInformation = @();
 	}
 	ElseIf($HTML)
 	{
@@ -25790,8 +28392,9 @@ Function OutputControllers
 Function ProcessHosting
 {
 	#original work on the Hosting was done by Kenny Baldwin
+	#V1.44 updated to match the V2 script
 	Write-Verbose "$(Get-Date): Processing Hosting"
-
+	
 	$Script:TotalHostingConnections = 0
 
 	If($MSWord -or $PDF)
@@ -25811,7 +28414,9 @@ Function ProcessHosting
 
 	$vmstorage = @()
 	$pvdstorage = @()
+	$tmpstorage = @()
 	$vmnetwork = @()
+	$IntelliCache = New-Object System.Collections.ArrayList
 
 	Write-Verbose "$(Get-Date): `tProcessing Hosting Units"
 	$HostingUnits = Get-ChildItem @XDParams1 -path 'xdhyp:\hostingunits' 4>$Null
@@ -25828,10 +28433,20 @@ Function ProcessHosting
 			{	
 				$pvdstorage += $storage.StoragePath
 			}
-			ForEach($network in $item.NetworkPath)
+			ForEach($storage in $item.AdditionalStorage.StorageLocations)
+			{	
+				$tmpstorage += $storage.StoragePath
+			}
+			ForEach($network in $item.PermittedNetworks)
 			{	
 				$vmnetwork += $network
 			}
+			
+			$obj1 = [PSCustomObject] @{
+				hypName = $item.RootPath			
+				IC      = $item.UseLocalStorageCaching			
+			}
+			$null = $IntelliCache.Add($obj1)
 		}
 	}
 	ElseIf($? -and $Null -eq $HostingUnits)
@@ -25846,7 +28461,7 @@ Function ProcessHosting
 	}
 
 	Write-Verbose "$(Get-Date): `tProcessing Hypervisors"
-	$Hypervisors = Get-BrokerHypervisorConnection @XDParams1
+	$Hypervisors = Get-BrokerHypervisorConnection @XDParams2
 	If($? -and $Null -ne $Hypervisors)
 	{
 		ForEach($Hypervisor in $Hypervisors)
@@ -25854,27 +28469,61 @@ Function ProcessHosting
 			$hypvmstorage = @()
 			$hyppvdstorage = @()
 			$hypnetwork = @()
-			$capabilities = $Hypervisor.Capabilities -join ', '	
+			$hypIntelliCache = @()
 			ForEach($storage in $vmstorage)
 			{
-				If($storage.Contains($Hypervisor.Name))
+                $tmpArray = $storage.Split("\")
+                $tmpHypName = $tmpArray[2]
+				If($tmpHypName -eq $Hypervisor.Name)
 				{		
 					$hypvmstorage += $storage		
 				}
+				$tmpArray = $Null
+				$tmpHypName = $Null
 			}
 			ForEach($storage in $pvdstorage)
 			{
-				If($storage.Contains($Hypervisor.Name))
+                $tmpArray = $storage.Split("\")
+                $tmpHypName = $tmpArray[2]
+				If($tmpHypName -eq $Hypervisor.Name)
 				{
 					$hyppvdstorage += $storage		
 				}
+				$tmpArray = $Null
+				$tmpHypName = $Null
+			}
+			ForEach($storage in $tmpstorage)
+			{
+                $tmpArray = $storage.Split("\")
+                $tmpHypName = $tmpArray[2]
+				If($tmpHypName -eq $Hypervisor.Name)
+				{		
+					$hyptmpstorage += $storage		
+				}
+				$tmpArray = $Null
+				$tmpHypName = $Null
 			}
 			ForEach($network in $vmnetwork)
 			{
-				If($network.Contains($Hypervisor.Name))
+                $tmpArray = $network.NetworkPath.Split("\")
+                $tmpHypName = $tmpArray[2]
+				If($tmpHypName -eq $Hypervisor.Name)
 				{
 					$hypnetwork += $network
 				}
+				$tmpArray = $Null
+				$tmpHypName = $Null
+			}
+			ForEach($ICItem in $IntelliCache)
+			{
+                $tmpArray = $ICItem.hypName.Split("\")
+                $tmpHypName = $tmpArray[2]
+				If($tmpHypName -eq $Hypervisor.Name)
+				{
+					$hypIntelliCache += $ICItem
+				}
+				$tmpArray = $Null
+				$tmpHypName = $Null
 			}
 			$xStorageName = ""
 			ForEach($Unit in $HostingUnits)
@@ -25916,10 +28565,7 @@ Function ProcessHosting
 						$xMaintMode = $Connection.MaintenanceMode
 						$xConnectionType = $Connection.ConnectionType
 						$xState = $Hypervisor.State
-						If((Get-ConfigServiceAddedCapability @XDParams1) -contains "ZonesSupport")
-						{
-							$xZoneName = $Connection.ZoneName
-						}
+						$xZoneName = $Connection.ZoneName
 						$xPowerActions = $Connection.metadata
 					}
 				}
@@ -25934,7 +28580,10 @@ Function ProcessHosting
 				$txt = "Unable to retrieve Hosting Connections"
 				OutputWarning $txt
 			}
-			OutputHosting $Hypervisor $xConnectionType $xAddress $xState $xUserName $xMaintMode $xStorageName $xHAAddress $xPowerActions $xScopes $xZoneName
+			OutputHosting $Hypervisor $xConnectionType $xAddress $xState `
+			$xUserName $xMaintMode $xStorageName $xHAAddress `
+			$xPowerActions $xScopes $xZoneName $hypvmstorage `
+			$hyppvdstorage $hypnetwork $hyptmpstorage $hypIntelliCache
 		}
 	}
 	ElseIf($? -and $Null -eq $Hypervisors)
@@ -25952,9 +28601,95 @@ Function ProcessHosting
 
 Function OutputHosting
 {
-	Param([object] $Hypervisor, [string] $xConnectionType, [string] $xAddress, [string] $xState, [string] $xUserName, [bool] $xMaintMode, [string] $xStorageName, [array] $xHAAddress, [array]$xPowerActions, [string] $xScopes, [string] $xZoneName)
+	Param([object] $Hypervisor, 
+	[string] $xConnectionType, 
+	[string] $xAddress, 
+	[string] $xState, 
+	[string] $xUserName, 
+	[bool] $xMaintMode, 
+	[string] $xStorageName, 
+	[array] $xHAAddress, 
+	[array] $xPowerActions, 
+	[string] $xScopes, 
+	[string] $xZoneName, 
+	[array] $hypvmstorage, 
+	[array] $hyppvdstorage, 
+	[array] $hypnetwork,
+	[array] $hyptmpstorage,
+	[array] $hypIntelliCache)
+	#V1.44 updated function to match the V2 script
+	
+	$xHAAddress = $xHAAddress | Sort-Object 
+	
+	$HypStdStorage = @()
+	ForEach($path in $hypvmstorage)
+	{
+		$tmp1 = $path.split("\")
+		$cnt1 = $tmp1.Length
+		$tmp2 = $tmp1[$cnt1-1]
 
-	$xHAAddress = $xHAAddress | Sort-Object
+		ForEach($tmp in $tmp2)
+		{
+			$tmp3 = $tmp.Split(".")
+			$HypStdStorage += $tmp3[0]
+		}
+	}
+	
+	$HypPersonalvDiskStorage = @()
+	ForEach($path in $HypPvDStorage)
+	{
+		$tmp1 = $path.split("\")
+		$cnt1 = $tmp1.Length
+		$tmp2 = $tmp1[$cnt1-1]
+
+		ForEach($tmp in $tmp2)
+		{
+			$tmp3 = $tmp.Split(".")
+			$HypPersonalvDiskStorage += $tmp3[0]
+		}
+	}
+	
+	$HypTempStorage = @()
+	ForEach($path in $hyptmpstorage)
+	{
+		$tmp1 = $path.split("\")
+		$cnt1 = $tmp1.Length
+		$tmp2 = $tmp1[$cnt1-1]
+
+		ForEach($tmp in $tmp2)
+		{
+			$tmp3 = $tmp.Split(".")
+			$HypTempStorage += $tmp3[0]
+		}
+	}
+	
+	$HypNetworkName = @()
+	ForEach($path in $hypnetwork.NetworkPath)
+	{
+		$tmp1 = $path.split("\")
+		$cnt1 = $tmp1.Length
+		$tmp2 = $tmp1[$cnt1-1]
+
+		ForEach($tmp in $tmp2)
+		{
+			$tmp3 = $tmp.Split(".")
+			$HypNetworkName += $tmp3[0]
+		}
+	}
+
+	$HypICName = @()
+	ForEach($item in $hypIntelliCache)
+	{
+		If($item.IC)
+		{
+			$ICState = "Enabled"
+		}
+		Else
+		{
+			$ICState = "Disabled"
+		}
+		$HypICName += $ICState
+	}
 	
 	$xxConnectionType = ""
 	Switch ($xConnectionType)
@@ -25990,19 +28725,80 @@ Function OutputHosting
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 3 0 $Hypervisor.Name
-		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{ Data = "Connection Name"; Value = $Hypervisor.Name; }
-		$ScriptInformation += @{ Data = "Type"; Value = $xxConnectionType; }
-		$ScriptInformation += @{ Data = "Address"; Value = $xAddress; }
-		$ScriptInformation += @{ Data = "State"; Value = $xxState; }
-		$ScriptInformation += @{ Data = "Username"; Value = $xUserName; }
-		$ScriptInformation += @{ Data = "Scopes"; Value = $xScopes; }
-		$ScriptInformation += @{ Data = "Maintenance Mode"; Value = $xxMaintMode; }
+		$ScriptInformation = New-Object System.Collections.ArrayList
+		$ScriptInformation.Add(@{Data = "Connection Name"; Value = $Hypervisor.Name; }) > $Null
+		$ScriptInformation.Add(@{Data = "Type"; Value = $xxConnectionType; }) > $Null
+		$ScriptInformation.Add(@{Data = "Address"; Value = $xAddress; }) > $Null
+		$ScriptInformation.Add(@{Data = "State"; Value = $xxState; }) > $Null
+		$ScriptInformation.Add(@{Data = "Username"; Value = $xUserName; }) > $Null
+		$ScriptInformation.Add(@{Data = "Scopes"; Value = $xScopes; }) > $Null
+		$ScriptInformation.Add(@{Data = "Maintenance Mode"; Value = $xxMaintMode; }) > $Null
 		If((Get-ConfigServiceAddedCapability @XDParams1) -contains "ZonesSupport")
 		{
-			$ScriptInformation += @{ Data = "Zone"; Value = $xZoneName; }
+			$ScriptInformation.Add(@{Data = "Zone"; Value = $xZoneName; }) > $Null
 		}
-		$ScriptInformation += @{ Data = "Storage resource name"; Value = $xStorageName; }
+		$ScriptInformation.Add(@{Data = "Storage resource name"; Value = $xStorageName; }) > $Null
+		If($HypNetworkName.Length -gt 0)
+		{
+			$ScriptInformation.Add(@{Data = "Networks"; Value = $HypNetworkName[0]; }) > $Null
+			$cnt = -1
+			ForEach($item in $HypNetworkName)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					$ScriptInformation.Add(@{Data = ""; Value = $item; }) > $Null
+				}
+			}
+		}
+		If($HypStdStorage.Length -gt 0)
+		{
+			$ScriptInformation.Add(@{Data = "Standard storage"; Value = $HypStdStorage[0]; }) > $Null
+			$cnt = -1
+			ForEach($item in $HypStdStorage)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					$ScriptInformation.Add(@{Data = ""; Value = $item; }) > $Null
+				}
+			}
+		}
+		If($HypPersonalvDiskStorage.Length -gt 0)
+		{
+			$ScriptInformation.Add(@{Data = "Personal vDisk storage"; Value = $HypPersonalvDiskStorage[0]; }) > $Null
+			$cnt = -1
+			ForEach($item in $HypPersonalvDiskStorage)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					$ScriptInformation.Add(@{Data = ""; Value = $item; }) > $Null
+				}
+			}
+		}
+		If($HypTempStorage.Length -gt 0)
+		{
+			$ScriptInformation.Add(@{Data = "Temporary storage"; Value = $HypTempStorage[0]; }) > $Null
+			$cnt = -1
+			ForEach($item in $HypTempStorage)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					$ScriptInformation.Add(@{Data = ""; Value = $item; }) > $Null
+				}
+			}
+		}
+		If($HypICName.Length -gt 0)
+		{
+			$ScriptInformation.Add(@{Data = "IntelliCache:"; Value = $HypICName[0]; }) > $Null
+		}
+
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
 		-List `
@@ -26025,25 +28821,26 @@ Function OutputHosting
 		{
 			$HAtmp += "$($tmpaddress)"
 		}
-		[System.Collections.Hashtable[]] $ScriptInformation = @()
-		$ScriptInformation += @{ Data = "High Availability Servers"; Value = $HAtmp[0]; }
+		
+		$ScriptInformation = New-Object System.Collections.ArrayList
+		$ScriptInformation.Add(@{Data = "High Availability Servers"; Value = $HAtmp[0]; }) > $Null
 		$cnt = -1
 		ForEach($tmp in $HATmp)
 		{
 			$cnt++
 			If($cnt -gt 0)
 			{
-				$ScriptInformation += @{ Data = ""; Value = $tmp; }
+				$ScriptInformation.Add(@{Data = ""; Value = $tmp; }) > $Null
 			}
 		}
-		$ScriptInformation += @{ Data = "Simultaneous actions (all types) [Absolute]"; Value = $xPowerActions[0].Value; }
-		$ScriptInformation += @{ Data = "Simultaneous actions (all types) [Percentage]"; Value = $xPowerActions[2].Value; }
-		$ScriptInformation += @{ Data = "Simultaneous Personal vDisk inventory updates [Absolute]"; Value = $xPowerActions[4].Value; }
-		$ScriptInformation += @{ Data = "Simultaneous Personal vDisk inventory updates [Percentage]"; Value = $xPowerActions[3].Value; }
-		$ScriptInformation += @{ Data = "Maximum new actions per minute"; Value = $xPowerActions[1].Value; }
+		$ScriptInformation.Add(@{Data = "Simultaneous actions (all types) [Absolute]"; Value = $xPowerActions[0].Value; }) > $Null
+		$ScriptInformation.Add(@{Data = "Simultaneous actions (all types) [Percentage]"; Value = $xPowerActions[2].Value; }) > $Null
+		$ScriptInformation.Add(@{Data = "Simultaneous Personal vDisk inventory updates [Absolute]"; Value = $xPowerActions[4].Value; }) > $Null
+		$ScriptInformation.Add(@{Data = "Simultaneous Personal vDisk inventory updates [Percentage]"; Value = $xPowerActions[3].Value; }) > $Null
+		$ScriptInformation.Add(@{Data = "Maximum new actions per minute"; Value = $xPowerActions[1].Value; }) > $Null
 		If($xPowerActions.Count -gt 5)
 		{
-			$ScriptInformation += @{ Data = "Connection options"; Value = $xPowerActions[5].Value; }
+			$ScriptInformation.Add(@{Data = "Connection options"; Value = $xPowerActions[5].Value; }) > $Null
 		}
 		$Table = AddWordTable -Hashtable $ScriptInformation `
 		-Columns Data,Value `
@@ -26077,6 +28874,66 @@ Function OutputHosting
 			Line 1 "Zone`t`t`t: " $xZoneName
 		}
 		Line 1 "Storage resource name`t: " $xStorageName
+		If($HypNetworkName.Length -gt 0)
+		{
+			Line 1 "Networks`t`t: " $HypNetworkName[0]
+			$cnt = -1
+			ForEach($item in $HypNetworkName)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					Line 4 "  " $item
+				}
+			}
+		}
+		If($HypStdStorage.Length -gt 0)
+		{
+			Line 1 "Standard storage`t: " $HypStdStorage[0]
+			$cnt = -1
+			ForEach($item in $HypStdStorage)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					Line 4 "  " $item
+				}
+			}
+		}
+		If($HypPersonalvDiskStorage.Length -gt 0)
+		{
+			Line 1 "Personal vDisk storage`t: " $HypPersonalvDiskStorage[0]
+			$cnt = -1
+			ForEach($item in $HypPersonalvDiskStorage)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					Line 4 "  " $item
+				}
+			}
+		}
+		If($HypTempStorage.Length -gt 0)
+		{
+			Line 1 "Temporary storage`t: " $HypTempStorage[0]
+			$cnt = -1
+			ForEach($item in $HypTempStorage)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					Line 4 "  " $item
+				}
+			}
+		}
+		If($HypICName.Length -gt 0)
+		{
+			Line 1 "IntelliCache`t`t: " $HypICName[0]
+		}
 		Line 0 ""
 		
 		Line 1 "Advanced"
@@ -26118,6 +28975,66 @@ Function OutputHosting
 			$rowdata += @(,('Zone',($htmlsilver -bor $htmlbold),$xZoneName,$htmlwhite))
 		}
 		$rowdata += @(,('Storage resource name',($htmlsilver -bor $htmlbold),$xStorageName,$htmlwhite))
+		If($HypNetworkName.Length -gt 0)
+		{
+			$rowdata += @(,('Network',($htmlsilver -bor $htmlbold),$HypNetworkName[0],$htmlwhite))
+			$cnt = -1
+			ForEach($item in $HypNetworkName)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$item,$htmlwhite))
+				}
+			}
+		}
+		If($HypStdStorage.Length -gt 0)
+		{
+			$rowdata += @(,('Standard storage',($htmlsilver -bor $htmlbold),$HypStdStorage[0],$htmlwhite))
+			$cnt = -1
+			ForEach($item in $HypStdStorage)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$item,$htmlwhite))
+				}
+			}
+		}
+		If($HypPersonalvDiskStorage.Length -gt 0)
+		{
+			$rowdata += @(,('Personal vDisk storage',($htmlsilver -bor $htmlbold),$HypPersonalvDiskStorage[0],$htmlwhite))
+			$cnt = -1
+			ForEach($item in $HypPersonalvDiskStorage)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$item,$htmlwhite))
+				}
+			}
+		}
+		If($HypTempStorage.Length -gt 0)
+		{
+			$rowdata += @(,('Temporary storage',($htmlsilver -bor $htmlbold),$HypTempStorage[0],$htmlwhite))
+			$cnt = -1
+			ForEach($item in $HypTempStorage)
+			{
+				$cnt++
+				
+				If($cnt -gt 0)
+				{
+					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$item,$htmlwhite))
+				}
+			}
+		}
+		If($HypICName.Length -gt 0)
+		{
+			$rowdata += @(,('IntelliCache:',($htmlsilver -bor $htmlbold),$HypICName[0],$htmlwhite))
+		}
 
 		$msg = ""
 		$columnWidths = @("150","200")
@@ -26173,26 +29090,11 @@ Function OutputHosting
 		}
 
 		Write-Verbose "$(Get-Date): `tProcessing Desktop OS Data"
-		$DesktopOSMachines = Get-BrokerMachine @XDParams2 -hypervisorconnectionname $Hypervisor.Name -sessionsupport "SingleSession"
+		$DesktopOSMachines = @(Get-BrokerMachine @XDParams2 -hypervisorconnectionname $Hypervisor.Name -sessionsupport "SingleSession")
 
 		If($? -and ($Null -ne $DesktopOSMachines))
 		{
-			[int]$cnt = 0
-			If($DesktopOSMachines -is [array])
-			{
-				$cnt = $DesktopOSMachines.Count
-			}
-			Else
-			{
-				If(![String]::IsNullOrEmpty($DesktopOSMachines))
-				{
-					$cnt = 1
-				}
-				Else
-				{
-					$cnt = 0
-				}
-			}
+			[int]$cnt = $DesktopOSMachines.Count
 			
 			If($MSWord -or $PDF)
 			{
@@ -26226,25 +29128,11 @@ Function OutputHosting
 		}
 
 		Write-Verbose "$(Get-Date): `tProcessing Server OS Data"
-		$ServerOSMachines = Get-BrokerMachine @XDParams2 -hypervisorconnectionname $Hypervisor.Name -sessionsupport "MultiSession"
+		$ServerOSMachines = @(Get-BrokerMachine @XDParams2 -hypervisorconnectionname $Hypervisor.Name -sessionsupport "MultiSession")
 		
 		If($? -and ($Null -ne $ServerOSMachines))
 		{
-			If($ServerOSMachines -is [array])
-			{
-				$cnt = $ServerOSMachines.Count
-			}
-			Else
-			{
-				If(![String]::IsNullOrEmpty($ServerOSMachines))
-				{
-					$cnt = 1
-				}
-				Else
-				{
-					$cnt = 0
-				}
-			}
+			[int]$cnt = $ServerOSMachines.Count
 
 			If($MSWord -or $PDF)
 			{
@@ -26278,53 +29166,42 @@ Function OutputHosting
 			OutputWarning $txt
 		}
 
-		Write-Verbose "$(Get-Date): `tProcessing Sessions Data"
-		$Sessions = Get-BrokerSession @XDParams1 -hypervisorconnectionname $Hypervisor.Name -SortBy UserName
-		If($? -and ($Null -ne $Sessions))
+		If($NoSessions -eq $False) #V2.27
 		{
-			If($Sessions -is [array])
+			Write-Verbose "$(Get-Date): `tProcessing Sessions Data"
+			$Sessions = @(Get-BrokerSession @XDParams2 -hypervisorconnectionname $Hypervisor.Name -SortBy UserName)
+			If($? -and ($Null -ne $Sessions))
 			{
-				$cnt = $Sessions.Count
+				[int]$cnt = $Sessions.Count
+
+				If($MSWord -or $PDF)
+				{
+					$Selection.InsertNewPage()
+					WriteWordLine 4 0 "Sessions ($($cnt))"
+				}
+				ElseIf($Text)
+				{
+					Line 0 ""
+					Line 0 "Sessions ($($cnt))"
+					Line 0 ""
+				}
+				ElseIf($HTML)
+				{
+					WriteHTMLLine 4 0 "Sessions ($($cnt))"
+				}
+				
+				OutputHostingSessions $Sessions
+			}
+			ElseIf($? -and ($Null -eq $Sessions))
+			{
+				$txt = "There are no Sessions"
+				OutputWarning $txt
 			}
 			Else
 			{
-				If(![String]::IsNullOrEmpty($Sessions))
-				{
-					$cnt = 1
-				}
-				Else
-				{
-					$cnt = 0
-				}
+				$txt = "Unable to retrieve Sessions"
+				OutputWarning $txt
 			}
-
-			If($MSWord -or $PDF)
-			{
-				$Selection.InsertNewPage()
-				WriteWordLine 4 0 "Sessions ($($cnt))"
-			}
-			ElseIf($Text)
-			{
-				Line 0 ""
-				Line 0 "Sessions ($($cnt))"
-				Line 0 ""
-			}
-			ElseIf($HTML)
-			{
-				WriteHTMLLine 4 0 "Sessions ($($cnt))"
-			}
-			
-			OutputHostingSessions $Sessions
-		}
-		ElseIf($? -and ($Null -eq $Sessions))
-		{
-			$txt = "There are no Sessions"
-			OutputWarning $txt
-		}
-		Else
-		{
-			$txt = "Unable to retrieve Sessions"
-			OutputWarning $txt
 		}
 	}
 }
@@ -26636,26 +29513,12 @@ Function OutputServerOSMachine
 Function OutputHostingSessions 
 {
 	Param([object] $Sessions)
+	#V1.44 remove all the desktop code as it is not used in this function
 	
 	ForEach($Session in $Sessions)
 	{
 		Write-Verbose "$(Get-Date): `t`t`tOutput session $($Session.UserName)"
-		#get the private desktop
-		#get desktop by Session Uid
-		$xMachineName = ""
-		#V1.42 Changed from the deprecated Get-BrokerDesktop to Get-BrokerMachine
-		#$Desktop = Get-BrokerDesktop -SessionUid $Session.Uid @XDParams1
-		$Desktop = Get-BrokerMachine -SessionUid $Session.Uid @XDParams1
 		
-		If($? -and $Null -ne $Desktop)
-		{
-			$xMachineName = $Desktop.MachineName
-		}
-		Else
-		{
-			$xMachineName = "Not Found"
-		}
-
 		If($Session.SessionSupport -eq "SingleSession")
 		{
 			$xSessionType = "Single"

--- a/XD7_Inventory.ps1
+++ b/XD7_Inventory.ps1
@@ -334,8 +334,8 @@
 .PARAMETER AddDateTime
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2018 at 6PM is 2018-06-01_1800.
-	Output filename will be ReportName_2018-06-01_1800.docx (or .pdf).
+	June 1, 2020 at 6PM is 2020-06-01_1800.
+	Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
 	This parameter is disabled by default.
 	This parameter has an alias of ADT.
 .PARAMETER Folder
@@ -605,10 +605,10 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript > .\XD7_Inventory.ps1 -Logging -StartDate 01/01/2018 -EndDate 01/31/2018
+	PS C:\PSScript > .\XD7_Inventory.ps1 -Logging -StartDate 01/01/2020 -EndDate 01/31/2020
 	
-	Creates a report with Configuration Logging details for the dates 01/01/2018 through 
-	01/31/2018.
+	Creates a report with Configuration Logging details for the dates 01/01/2020 through 
+	01/31/2020.
 	
 	Will use all Default values.
 	HKEY_CURRENT_USER\Software\Microsoft\Office\Common\UserInfo\CompanyName="Carl 
@@ -620,11 +620,11 @@
 	Sideline for the Cover Page format.
 	Administrator for the User Name.
 .EXAMPLE
-	PS C:\PSScript > .\XD7_Inventory.ps1 -Logging -StartDate "06/01/2018 10:00:00" -EndDate 
-	"06/01/2018 14:00:00"
+	PS C:\PSScript > .\XD7_Inventory.ps1 -Logging -StartDate "06/01/2020 10:00:00" -EndDate 
+	"06/01/2020 14:00:00"
 	
 	Creates a report with Configuration Logging details for the time range 
-	06/01/2018 10:00:00AM through 06/01/2018 02:00:00PM.
+	06/01/2020 10:00:00AM through 06/01/2020 02:00:00PM.
 	
 	Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
 	
@@ -755,8 +755,8 @@
 
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2018 at 6PM is 2018-06-01_1800.
-	Output filename will be XD7SiteName_2018-06-01_1800.docx
+	June 1, 2020 at 6PM is 2020-06-01_1800.
+	Output filename will be XD7SiteName_2020-06-01_1800.docx
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory.ps1 -PDF -AddDateTime
 	
@@ -772,8 +772,8 @@
 
 	Adds a date time stamp to the end of the file name.
 	Time stamp is in the format of yyyy-MM-dd_HHmm.
-	June 1, 2018 at 6PM is 2018-06-01_1800.
-	Output filename will be XD7SiteName_2018-06-01_1800.pdf
+	June 1, 2020 at 6PM is 2020-06-01_1800.
+	Output filename will be XD7SiteName_2020-06-01_1800.pdf
 .EXAMPLE
 	PS C:\PSScript > .\XD7_Inventory.ps1 -Hardware
 	
@@ -906,7 +906,7 @@
 	NAME: XD7_Inventory.ps1
 	VERSION: 1.44
 	AUTHOR: Carl Webster
-	LASTEDIT: October 3, 2019
+	LASTEDIT: December 17, 2019
 #>
 
 #endregion
@@ -1095,12 +1095,17 @@ Param(
 
 # Version 1.0 released to the community on June 12, 2015
 
-#Version 1.44
+#Version 1.44 17-Dec-2019
 #	Add a NoSessions parameter to exclude Machine Catalog, Application and Hosting session data from the report
 #	Added missing "Will shutdown after use" to the Hosting section in Function OutputMachineDetails
+#	Fix Swedish Table of Contents (Thanks to Johan Kallio)
+#		From 
+#			'sv-'	{ 'Automatisk innehållsförteckning2'; Break }
+#		To
+#			'sv-'	{ 'Automatisk innehållsförteckn2'; Break }
 #	Updated Function CheckExcelPrereq to match the V2 script
 #	Updated Function CheckWordPrereq to match the V2 script
-#	Updated Function OutputDeliveryGroupDetails  by removing unused variable $xDeliveryGroupType
+#	Updated Function OutputDeliveryGroupDetails by removing unused variable $xDeliveryGroupType
 #	Updated Function OutputDeliveryGroupUtilization to match the V2 script
 #	Updated Function OutputHosting to match the V2 script
 #	Updated Function OutputHostingSessions by removing all desktop code as it is not used
@@ -1108,6 +1113,7 @@ Param(
 #		Updated Function GetComputerWMIInfo to pass the computer name parameter to the OutputNicItem function
 #	Updated Function ProcessCitrixPolicies to match the V2 script
 #	Updated Function ProcessHosting to match the V2 script
+#	Updated help text
 #
 #Version1.43 21-Apr-2019
 #	If Policies parameter is used, check to see if PowerShell session is elevated. If it is,
@@ -2992,7 +2998,8 @@ Function SetWordHashTable
 			'nb-'	{ 'Automatisk tabell 2'; Break }
 			'nl-'	{ 'Automatische inhoudsopgave 2'; Break }
 			'pt-'	{ 'Sumário Automático 2'; Break }
-			'sv-'	{ 'Automatisk innehållsförteckning2'; Break }
+			# fix in 1.44 thanks to Johan Kallio 'sv-'	{ 'Automatisk innehållsförteckning2'; Break }
+			'sv-'	{ 'Automatisk innehållsförteckn2'; Break }
 			'zh-'	{ '自动目录 2'; Break }
 		}
 	)
@@ -31210,6 +31217,12 @@ Function ProcessScriptEnd
 	$Str = $Null
 	$ErrorActionPreference = $SaveEAPreference
 	$Script:DoPolicies = $Null
+			
+	Write-Host "                                                                                    " -BackgroundColor Black -ForegroundColor White
+	Write-Host "               This FREE script was brought to you by Conversant Group              " -BackgroundColor Black -ForegroundColor White
+	Write-Host "We design, build, and manage infrastructure for a secure, dependable user experience" -BackgroundColor Black -ForegroundColor White
+	Write-Host "                       Visit our website conversantgroup.com                        " -BackgroundColor Black -ForegroundColor White
+	Write-Host "                                                                                    " -BackgroundColor Black -ForegroundColor White
 }
 #endregion
 

--- a/XD7_Inventory_V1_ReadMe.rtf
+++ b/XD7_Inventory_V1_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -77,12 +77,12 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid2070\rsid219208\rsid265763\rsid677819\rsid1076041\rsid1146462\rsid1654655\rsid2579094\rsid2584542\rsid2902416\rsid2978753
 \rsid3557177\rsid3761251\rsid3830441\rsid3831187\rsid4619633\rsid4925376\rsid5267713\rsid6053627\rsid6237392\rsid6258287\rsid6509366\rsid6885713\rsid7367214\rsid7687390\rsid7746862\rsid7763859\rsid7809154\rsid7892821\rsid8394203\rsid8410782\rsid8473952
-\rsid8928184\rsid9112866\rsid9186743\rsid9380266\rsid9644665\rsid9648170\rsid9986361\rsid10033903\rsid10638569\rsid11148983\rsid11353962\rsid11410367\rsid11488686\rsid11551746\rsid11809962\rsid12216897\rsid12801149\rsid13248665\rsid13308089\rsid13663721
-\rsid13853169\rsid13987238\rsid14298582\rsid14697282\rsid14881286\rsid15028178\rsid15424297\rsid15739805\rsid15757842\rsid15955795\rsid16207041\rsid16267726\rsid16269241\rsid16283129\rsid16408172\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0
-\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster, Carl}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo10\dy3\hr16\min20}{\version43}{\edmins11763}{\nofpages27}{\nofwords8153}
-{\nofchars46473}{\nofcharsws54517}{\vern113}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid8928184\rsid9112866\rsid9186743\rsid9372083\rsid9380266\rsid9644665\rsid9648170\rsid9986361\rsid10033903\rsid10638569\rsid11148983\rsid11353962\rsid11410367\rsid11488686\rsid11551746\rsid11809962\rsid12216897\rsid12801149\rsid13248665\rsid13308089
+\rsid13663721\rsid13853169\rsid13987238\rsid14298582\rsid14697282\rsid14881286\rsid15028178\rsid15424297\rsid15739805\rsid15757842\rsid15955795\rsid16207041\rsid16267726\rsid16269241\rsid16283129\rsid16408172\rsid16517051\rsid16597410}{\mmathPr
+\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo12\dy17\hr14\min43}{\version44}{\edmins11764}
+{\nofpages27}{\nofwords8153}{\nofchars46475}{\nofcharsws54519}{\vern119}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MTQ3MDQzN7I0MTY0MDVQ0lEKTi0uzszPAykwrgUAVQ4iviwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
@@ -143,7 +143,7 @@ ess of the computer, from the full XenDesktop 7.x installation media, install th
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 iv.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Configuration_PowerShell_SnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 v.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\ConfigurationLogging_PowerShell_SnapIn_x??
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Configu\hich\af37\dbch\af31505\loch\f37 rationLogging_PowerShell_SnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 vi.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Del}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 egatedAdmin_PowerShellSnapIn_x??}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 
@@ -151,19 +151,18 @@ ess of the computer, from the full XenDesktop 7.x installation media, install th
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 EnvTest_PowerShell_SnapIn_x??}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 viii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controlle\hich\af37\dbch\af31505\loch\f37 r\\
-Host_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 ix.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\MachineCreation_PowerShellSnapIn_x??
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Host_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 ix.\tab}\hich\af37\dbch\af31505\loch\f37 Cit\hich\af37\dbch\af31505\loch\f37 rix Desktop Delivery Controller\\
+MachineCreation_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 x.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Monitor_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xi.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Storefront_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xii.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix P\hich\af37\dbch\af31505\loch\f37 olicy\\CitrixGroupPolicyManagement_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xii.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Policy\\CitrixGroupPolicyManagement_x?\hich\af37\dbch\af31505\loch\f37 ?
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xiii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 DesktopStudio\\PxAppV_Studio_PowershellSnapin_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xiv.\tab}\hich\af37\dbch\af31505\loch\f37 Licensing\\LicensingAdmin_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Install the Citrix Group Policy PowerShell module.}{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  There are two options, download the module or copy the fil\hich\af37\dbch\af31505\loch\f37 e from a Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid9112866 
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  There are two options, download the module or copy the file from a Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 Download the file:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
@@ -171,7 +170,7 @@ Host_PowerShell_SnapIn_x??
 {\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000020f7}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid1076041\charrsid1076041 \hich\af37\dbch\af31505\loch\f37 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000020f700}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid1076041\charrsid1076041 \hich\af37\dbch\af31505\loch\f37 
 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041\charrsid1076041 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the file to your default download folder.}{
@@ -189,19 +188,19 @@ Current\\Utilities
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 ii.\tab}\hich\af37\dbch\af31505\loch\f37 On a 64-bit Controller, go to %PROGRAMFILES(x86)%\\Citrix\\Scout\\Current\\Utilities
 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
-If you are running 32-bit or 64-bit Windows, copy the fi\hich\af37\dbch\af31505\loch\f37 le}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid12801149 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
-\i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 
-\ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
-\hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 If you are running 32-bi
+\hich\af37\dbch\af31505\loch\f37 t or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid12801149 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 
+\hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
+\i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
+, in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
+\hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid8410782\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 If you are running 64-bit Windows, }{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid16597410 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 
-\ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 
-\ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 
-\hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid8410782\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 If you are runni
+\hich\af37\dbch\af31505\loch\f37 ng 64-bit Windows, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid16597410 
+\hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules}{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 
+Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Note:}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  The Citrix.GroupPolicy.Commands.psm1 file is }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 not}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
@@ -209,10 +208,10 @@ If you are running 32-bit or 64-bit Windows, copy the fi\hich\af37\dbch\af31505\
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://\hich\af37\dbch\af31505\loch\f37 
 support.citrix.com/article/CTX130147" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000000000000000000000000080000800000000070000000003f00000000006a}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000000000000000000000000080000800000000070000000003f00000000006afb}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 
 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2070 \hich\af37\dbch\af31505\loch\f37  }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is fr\hich\af37\dbch\af31505\loch\f37 om Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 
+\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is f\hich\af37\dbch\af31505\loch\f37 rom Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \hich\af37\dbch\af31505\loch\f37 The updated version allows the policy cmdlets to be run against a remote Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 
  You cannot use the updated version to run against a remote XenApp 6.5 Collector.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
@@ -226,8 +225,8 @@ Script Usage
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 
 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventory.ps1 }{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 in your PowerShell scripts folder.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, change to your PowerShell scripts}{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13853169 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, change to your PowerShell scri
+\hich\af37\dbch\af31505\loch\f37 pts}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13853169 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 3.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, type in:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 .\\\hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 \ai\af37\afs22 
@@ -238,7 +237,7 @@ Script Usage
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 
 By default, a Microsoft Word document is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11488686\charrsid13987238 .
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \hich\af37\dbch\af31505\loch\f37 
 PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 6.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
@@ -259,7 +258,7 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \i\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 -AdminAddress DDCName }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full \hich\af37\dbch\af31505\loch\f37 help text is available.
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\X}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 _Inventory.ps1 \hich\f37 \endash \loch\f37 full
 \par 
@@ -284,85 +283,85 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\f
 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-MSWord] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-Applicatio\hich\af2\dbch\af31505\loch\f2 ns] [-DeliveryGroups] [-DeliveryGroupsUtilization] 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-A\hich\af2\dbch\af31505\loch\f2 pplications] [-DeliveryGroups] [-DeliveryGroupsUtilization] 
 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-MaxDetails] [-NoSessions] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <Strin\hich\af2\dbch\af31505\loch\f2 
-g>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-StoreFront] [-AddDateT\hich\af2\dbch\af31505\loch\f2 
+ime] [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
 XD7_Inventory.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Compa\hich\af2\dbch\af31505\loch\f2 
-nyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-HTML] [-MSWord] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-Comp\hich\af2\dbch\af31505\loch\f2 anyName <String>] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-HTML] [-MSWord] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-PDF] [-Text] [-Administrators] [-Applications] [-DeliveryGroups] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Logging] [-StartDate <DateTime>] [-EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-Machine\hich\af2\dbch\af31505\loch\f2 
-Catalogs] [-MaxDetails] [-NoSessions] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Logging] [-StartDate <DateTi\hich\af2\dbch\af31505\loch\f2 me>] [-EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-MachineCatalogs] [-MaxDetails] [-NoSessions] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String>] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL] -From <String> -To }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String> [-Dev] [-ScriptIn\hich\af2\dbch\af31505\loch\f2 fo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String>] -SmtpServer <String> [-SmtpPort <Int32>] [-Us\hich\af2\dbch\af31505\loch\f2 eSSL] -From <String> -To }
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String> [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
 XD7_Inventory.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <S\hich\af2\dbch\af31505\loch\f2 tring>] [-PDF] }{
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-PDF] }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-MaxDetails] [-NoSessions] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies]\hich\af2\dbch\af31505\loch\f2 
- [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalog\hich\af2\dbch\af31505\loch\f2 s] [-MaxDetails] [-NoSessions] [-Policies] [-NoPolicies] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
 XD7_Inventory.ps1 [-AdminAddress <String>] [-HTML] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [\hich\af2\dbch\af31505\loch\f2 
--DeliveryGroupsUtilization] [-Hosting] [-Logging] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoSessions] [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoSess\hich\af2\dbch\af31505\loch\f2 
+ions] [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }
-{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Secti\hich\af2\dbch\af31505\loch\f2 on <String>] [-Dev] [-ScriptInfo] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid6885713 
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [\hich\af2\dbch\af31505\loch\f2 -Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateT\hich\af2\dbch\af31505\loch\f2 ime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoSessions] [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoSessions] [-Policies] [-NoPolicies] [-NoADPolicies] [-St\hich\af2\dbch\af31505\loch\f2 
+oreFront] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }
 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 DESC\hich\af2\dbch\af31505\loch\f2 RIPTION
+\par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
 \par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.0 through 7.7 Site using Microsoft
-\par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text or HTML.
+\par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, \hich\af2\dbch\af31505\loch\f2 plain text or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This script requires at least PowerShell version 3 but runs best in version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and r\hich\af2\dbch\af31505\loch\f2 un
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This scrip\hich\af2\dbch\af31505\loch\f2 t was developed and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 8.1 VM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the -AdminAddress (AA) parameter.
@@ -370,7 +369,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     This script supports versions of XenApp/XenDesktop from 7.0 to 7.7.
 \par \hich\af2\dbch\af31505\loch\f2     Version 7.8+ is a separate script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary \hich\af2\dbch\af31505\loch\f2 information for:
+\par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
@@ -380,7 +379,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio\hich\af2\dbch\af31505\loch\f2  for:
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   The Summary information is what is shown in the top half of Citrix Studio for:
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
@@ -390,25 +389,25 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     Using the\hich\af2\dbch\af31505\loch\f2  MachineCatalogs parameter can cause the report to take a very long time to
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
-\par \hich\af2\dbch\af31505\loch\f2     complete and can g\hich\af2\dbch\af31505\loch\f2 enerate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an ex\hich\af2\dbch\af31505\loch\f2 tremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
 \par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to complete and generate an exceptionally long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the X\hich\af2\dbch\af31505\loch\f2 enDesktop 7.x Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.x Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for\hich\af2\dbch\af31505\loch\f2  the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Finnish
+\par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
@@ -423,7 +422,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         to.
 \par \hich\af2\dbch\af31505\loch\f2         This can be provided as a host name or an IP address.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to LocalHost.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
+\par \hich\af2\dbch\af31505\loch\f2         This pa\hich\af2\dbch\af31505\loch\f2 rameter has an alias of AA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -432,77 +431,77 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013\hich\af2\dbch\af31505\loch\f2 /2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010\hich\af2\dbch\af31505\loch\f2 )
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value
+\par \hich\af2\dbch\af31505\loch\f2         Posi\hich\af2\dbch\af31505\loch\f2 tion?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Page\hich\af2\dbch\af31505\loch\f2 s have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
+\par \hich\af2\dbch\af31505\loch\f2     -Comp\hich\af2\dbch\af31505\loch\f2 anyFax <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cove\hich\af2\dbch\af31505\loch\f2 r Page.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default v\hich\af2\dbch\af31505\loch\f2 alue
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <S\hich\af2\dbch\af31505\loch\f2 tring>
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone f\hich\af2\dbch\af31505\loch\f2 ield:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
@@ -510,59 +509,59 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
-\par \hich\af2\dbch\af31505\loch\f2         (default cover pages i\hich\af2\dbch\af31505\loch\f2 n Word en-US)
+\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't \hich\af2\dbch\af31505\loch\f2 work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in\hich\af2\dbch\af31505\loch\f2  2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 afte\hich\af2\dbch\af31505\loch\f2 r title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if yo\hich\af2\dbch\af31505\loch\f2 u like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (W\hich\af2\dbch\af31505\loch\f2 ord 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point\hich\af2\dbch\af31505\loch\f2 )
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually chan\hich\af2\dbch\af31505\loch\f2 ged to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; bo\hich\af2\dbch\af31505\loch\f2 x needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, wo\hich\af2\dbch\af31505\loch\f2 rks in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless change\hich\af2\dbch\af31505\loch\f2 d to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Tr\hich\af2\dbch\af31505\loch\f2 anscend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSW\hich\af2\dbch\af31505\loch\f2 ORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -570,16 +569,16 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
+\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alia\hich\af2\dbch\af31505\loch\f2 s of UN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input\hich\af2\dbch\af31505\loch\f2 ?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       f\hich\af2\dbch\af31505\loch\f2 alse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
@@ -587,59 +586,78 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?               \hich\af2\dbch\af31505\loch\f2      named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 set True if no other output format is selected.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output form\hich\af2\dbch\af31505\loch\f2 at is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2   false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be ins\hich\af2\dbch\af31505\loch\f2 talled.
+\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Po\hich\af2\dbch\af31505\loch\f2 sition?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Admin\hich\af2\dbch\af31505\loch\f2 istrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Administrator S\hich\af2\dbch\af31505\loch\f2 copes and Roles.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Admins.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an al\hich\af2\dbch\af31505\loch\f2 ias of Apps.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disab\hich\af2\dbch\af31505\loch\f2 led by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcar\hich\af2\dbch\af31505\loch\f2 d characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all desktops in all Desktop (Delivery) Groups.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         time to complet\hich\af2\dbch\af31505\loch\f2 e and can generate an extremely long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This para\hich\af2\dbch\af31505\loch\f2 meter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -647,75 +665,56 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all desktops in all Desktop (Delivery) Groups.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        time to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
-\par \hich\af2\dbch\af31505\loch\f2         long repo\hich\af2\dbch\af31505\loch\f2 rt.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 days
-\par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
+\par \hich\af2\dbch\af31505\loch\f2         depending on the information in \hich\af2\dbch\af31505\loch\f2 the database.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This opt\hich\af2\dbch\af31505\loch\f2 ion is only available when the report is generated in Word and requires
+\par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word and requires
 \par \hich\af2\dbch\af31505\loch\f2         Micosoft Excel to be locally installed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer report.
+\par \hich\af2\dbch\af31505\loch\f2         time to\hich\af2\dbch\af31505\loch\f2  complete and generates a longer report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value\hich\af2\dbch\af31505\loch\f2                 False
+\par \hich\af2\dbch\af31505\loch\f2         Default value               \hich\af2\dbch\af31505\loch\f2  False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts, Host Connections and Resources.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by\hich\af2\dbch\af31505\loch\f2  default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard char\hich\af2\dbch\af31505\loch\f2 acters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Logging [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by default, details for the previous
 \par \hich\af2\dbch\af31505\loch\f2         seven days.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Requi\hich\af2\dbch\af31505\loch\f2 red?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
-\par \hich\af2\dbch\af31505\loch\f2         Start date for the Configuration Logging report.
+\par \hich\af2\dbch\af31505\loch\f2         Start date for the \hich\af2\dbch\af31505\loch\f2 Configuration Logging report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24 hour format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default is\hich\af2\dbch\af31505\loch\f2  today's date minus seven days.
+\par \hich\af2\dbch\af31505\loch\f2         The default is today's date minus seven d\hich\af2\dbch\af31505\loch\f2 ays.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -737,12 +736,12 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
+\par \hich\af2\dbch\af31505\loch\f2         Default \hich\af2\dbch\af31505\loch\f2 value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detai\hich\af2\dbch\af31505\loch\f2 led information for all machines in all Machine Catalogs.
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
@@ -761,7 +760,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
+\par \hich\af2\dbch\af31505\loch\f2         Adds maximu\hich\af2\dbch\af31505\loch\f2 m detail to the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
 \par \hich\af2\dbch\af31505\loch\f2                 Administrators
@@ -769,59 +768,89 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2                 DeliveryGroups
 \par \hich\af2\dbch\af31505\loch\f2                 HardWare
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Logging
-\par \hich\af2\dbch\af31505\loch\f2                 MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2                 Logging
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2          MachineCatalogs
 \par \hich\af2\dbch\af31505\loch\f2                 Policies
 \par \hich\af2\dbch\af31505\loch\f2                 StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoADPolicies.
 \par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoSessions.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extrem\hich\af2\dbch\af31505\loch\f2 ely large report and
+\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
 \par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pip\hich\af2\dbch\af31505\loch\f2 eline input?       false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoSessions [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes Machine Catalog, Application and Hosting session data from the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the MaxDetails parameter does not change this setting.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Using the MaxDetails parameter does not change this setting.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NS.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 efault value                False
+\par \hich\af2\dbch\af31505\loch\f2         Defau\hich\af2\dbch\af31505\loch\f2 lt value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Note: The Citr\hich\af2\dbch\af31505\loch\f2 ix Group Policy PowerShell module will not load from an elevated
+\par \hich\af2\dbch\af31505\loch\f2         Note: The Citrix Group Policy PowerShell module will not load from an elevated
 \par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
-\par \hich\af2\dbch\af31505\loch\f2         If the module is manually imported, the module is not detected from an elevated
+\par \hich\af2\dbch\af31505\loch\f2         If the module is manually imported, the module is not \hich\af2\dbch\af31505\loch\f2 detected from an elevated
 \par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause\hich\af2\dbch\af31505\loch\f2  the report to take a very long time
+\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report to take a very long time
 \par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies and NoADPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, \hich\af2\dbch\af31505\loch\f2 NoPolicies and NoADPolicies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is \hich\af2\dbch\af31505\loch\f2 given to NoPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both Policies and NoADPolicies results in only policies created in Studio
 \par \hich\af2\dbch\af31505\loch\f2         being in the output document.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fals\hich\af2\dbch\af31505\loch\f2 e
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD based policy information from the output document.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?           \hich\af2\dbch\af31505\loch\f2          named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD based policy information from the output d\hich\af2\dbch\af31505\loch\f2 ocument.
+\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, where there may be thousands
+\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        This parameter has an alias of NoAD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -829,63 +858,35 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD based policy information from the output document.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is dis\hich\af2\dbch\af31505\loch\f2 abled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcar\hich\af2\dbch\af31505\loch\f2 d characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD based policy information from the output document.
-\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, wh\hich\af2\dbch\af31505\loch\f2 ere there may be thousands
-\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -StoreFront [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Give detailed information for StoreFront.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value            \hich\af2\dbch\af31505\loch\f2     False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   June 1, 2018 at 6PM is 2018-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2018-06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 
+\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         This paramet\hich\af2\dbch\af31505\loch\f2 er is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Acce\hich\af2\dbch\af31505\loch\f2 pt wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies t\hich\af2\dbch\af31505\loch\f2 he optional output folder to save the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -893,31 +894,31 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Ha\hich\af2\dbch\af31505\loch\f2 rdware [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an a\hich\af2\dbch\af31505\loch\f2 ccount with permission to retrieve hardware information (i.e. Domain Admin
+\par \hich\af2\dbch\af31505\loch\f2         This \hich\af2\dbch\af31505\loch\f2 parameter may require the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin
 \par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the\hich\af2\dbch\af31505\loch\f2  time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is di\hich\af2\dbch\af31505\loch\f2 sabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Defau\hich\af2\dbch\af31505\loch\f2 lt value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String>
 \par \hich\af2\dbch\af31505\loch\f2         Processes a specific section of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
-\par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
-\par \hich\af2\dbch\af31505\loch\f2                 Apps (Applic\hich\af2\dbch\af31505\loch\f2 ations)
+\par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators\hich\af2\dbch\af31505\loch\f2 )
+\par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications)
 \par \hich\af2\dbch\af31505\loch\f2                 AppV
 \par \hich\af2\dbch\af31505\loch\f2                 Catalogs (Machine Catalogs)
 \par \hich\af2\dbch\af31505\loch\f2                 Config (Configuration)
@@ -926,19 +927,19 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
 \par \hich\af2\dbch\af31505\loch\f2                 Licensing
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                Policies
+\par \hich\af2\dbch\af31505\loch\f2                 Policies
 \par \hich\af2\dbch\af31505\loch\f2                 StoreFront
 \par \hich\af2\dbch\af31505\loch\f2                 Zones
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Notes:
-\par \hich\af2\dbch\af31505\loch\f2         Using Logging will force the Logging switch to True.
-\par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the\hich\af2\dbch\af31505\loch\f2  Policies switch to True.
+\par \hich\af2\dbch\af31505\loch\f2         Using Logging w\hich\af2\dbch\af31505\loch\f2 ill force the Logging switch to True.
+\par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the Policies switch to True.
 \par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies switch is used, the script will terminate.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?\hich\af2\dbch\af31505\loch\f2                     named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -946,7 +947,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?              \hich\af2\dbch\af31505\loch\f2       true
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -956,19 +957,19 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Re\hich\af2\dbch\af31505\loch\f2 quired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard ch\hich\af2\dbch\af31505\loch\f2 aracters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whe\hich\af2\dbch\af31505\loch\f2 ther to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value           \hich\af2\dbch\af31505\loch\f2      False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -976,7 +977,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         true
+\par \hich\af2\dbch\af31505\loch\f2         Required? \hich\af2\dbch\af31505\loch\f2                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -984,44 +985,44 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpSe\hich\af2\dbch\af31505\loch\f2 rver is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?\hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer \hich\af2\dbch\af31505\loch\f2 requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a t\hich\af2\dbch\af31505\loch\f2 ext file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                 \hich\af2\dbch\af31505\loch\f2    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?         \hich\af2\dbch\af31505\loch\f2            false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
+\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for trou\hich\af2\dbch\af31505\loch\f2 bleshooting.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1030,10 +1031,10 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2         This cmdl\hich\af2\dbch\af31505\loch\f2 et supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/f\hich\af2\dbch\af31505\loch\f2 wlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.m\hich\af2\dbch\af31505\loch\f2 icrosoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
@@ -1046,41 +1047,41 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERS\hich\af2\dbch\af31505\loch\f2 ION: 1.44
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.44
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: October 3, 2019
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 December 17, 2019}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------\hich\af2\dbch\af31505\loch\f2 ---------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micr\hich\af2\dbch\af31505\loch\f2 osoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddr\hich\af2\dbch\af31505\loch\f2 ess.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Admi\hich\af2\dbch\af31505\loch\f2 nAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Ad\hich\af2\dbch\af31505\loch\f2 ministrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
 \par 
 \par 
@@ -1091,14 +1092,14 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyN\hich\af2\dbch\af31505\loch\f2 ame="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USE\hich\af2\dbch\af31505\loch\f2 R\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the Use\hich\af2\dbch\af31505\loch\f2 r Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1106,12 +1107,12 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -TEXT
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\XD7_Inventory.ps1 -TEXT
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl \hich\af2\dbch\af31505\loch\f2 Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1123,12 +1124,12 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\X\hich\af2\dbch\af31505\loch\f2 D7_Inventory.ps1 -HTML
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -HTML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1138,19 +1139,19 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 6 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURREN\hich\af2\dbch\af31505\loch\f2 T_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwar\hich\af2\dbch\af31505\loch\f2 e\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline\hich\af2\dbch\af31505\loch\f2  for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover\hich\af2\dbch\af31505\loch\f2  Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
@@ -1160,11 +1161,11 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -DeliveryGroups
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in al\hich\af2\dbch\af31505\loch\f2 l Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micr\hich\af2\dbch\af31505\loch\f2 osoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1176,32 +1177,32 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory.ps1 -DeliveryGroupsUtilization
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -DeliveryGroupsUtilization
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilization details for all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     A\hich\af2\dbch\af31505\loch\f2 dministrator for the User Name.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------------------\hich\af2\dbch\af31505\loch\f2 -------- EXAMPLE 9 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -DeliveryGroups -MachineCatalogs
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs and
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalo\hich\af2\dbch\af31505\loch\f2 gs and
 \par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl\hich\af2\dbch\af31505\loch\f2  Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1224,7 +1225,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Admi\hich\af2\dbch\af31505\loch\f2 nistrator for the User Name.
 \par 
 \par 
 \par 
@@ -1234,8 +1235,8 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Policies.
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT\hich\af2\dbch\af31505\loch\f2 _USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1256,6 +1257,24 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $e\hich\af2\dbch\af31505\loch\f2 nv:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory.ps1 -NoADPolicies
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softw\hich\af2\dbch\af31505\loch\f2 are\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1265,25 +1284,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 13 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -NoADPolicies
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based Policy information.
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Administrator for the User Name.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14\hich\af2\dbch\af31505\loch\f2  --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Policies -NoADPolicies
 \par 
@@ -1291,9 +1292,9 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKE\hich\af2\dbch\af31505\loch\f2 Y_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1303,19 +1304,19 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------\hich\af2\dbch\af31505\loch\f2 ------------- EXAMPLE 15 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Administrators
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Administrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2     Creat\hich\af2\dbch\af31505\loch\f2 es a report with full details on Administrator Scopes and Roles.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\User\hich\af2\dbch\af31505\loch\f2 Info\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1324,15 +1325,45 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate 01/01/2018 -EndDate 01/31/2018
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2  -EndDate 01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713\charrsid6885713 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Create\hich\af2\dbch\af31505\loch\f2 s a report with Configuration Logging details for the dates 01/01/2018 through
-\par \hich\af2\dbch\af31505\loch\f2     01/31/2018.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the dates 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2  through
+\par \hich\af2\dbch\af31505\loch\f2     01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 .
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwar\hich\af2\dbch\af31505\loch\f2 e\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate "06/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2  10:00:00" -EndDate
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     "06/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 
+ 14:00:00"
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the time range
+\par \hich\af2\dbch\af31505\loch\f2     06/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 
+ 10:00:00AM through 06/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2  02:00:00PM.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be e\hich\af2\dbch\af31505\loch\f2 ither 00 or 59.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1342,39 +1373,15 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate "06/01/2018 10:00:00" -EndDate
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     "06/01/2018 14:00:00"
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the tim\hich\af2\dbch\af31505\loch\f2 e range
-\par \hich\af2\dbch\af31505\loch\f2     06/01/2018 10:00:00AM through 06/01/2018 02:00:00PM.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Com\hich\af2\dbch\af31505\loch\f2 panyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for th\hich\af2\dbch\af31505\loch\f2 e User Name.
-\par 
-\par 
-\par 
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Hosting
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inven\hich\af2\dbch\af31505\loch\f2 tory.ps1 -Hosting
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Hosts, Host Connections and Resources.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Of\hich\af2\dbch\af31505\loch\f2 fice\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\So\hich\af2\dbch\af31505\loch\f2 ftware\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1390,14 +1397,14 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offi\hich\af2\dbch\af31505\loch\f2 ce\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Administrator for the User Name.
 \par 
 \par 
 \par 
@@ -1408,29 +1415,29 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Policies -Hosting -StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
-\par \hich\af2\dbch\af31505\loch\f2         Machin\hich\af2\dbch\af31505\loch\f2 es in all Machine Catalogs
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report w\hich\af2\dbch\af31505\loch\f2 ith full details for all:
+\par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections and Resources
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Commo\hich\af2\dbch\af31505\loch\f2 n\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administra\hich\af2\dbch\af31505\loch\f2 tor for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MC -DG -Apps -Policies -Hosting
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MC -DG -Apps -Policies -Hos\hich\af2\dbch\af31505\loch\f2 ting
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
@@ -1439,13 +1446,13 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections and Resources
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sidelin\hich\af2\dbch\af31505\loch\f2 e for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
@@ -1453,15 +1460,15 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid6885713\charrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName\hich\af2\dbch\af31505\loch\f2  "Carl Webster" -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Carl W\hich\af2\dbch\af31505\loch\f2 ebster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         Controller named DDC01 for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2         Controller nam\hich\af2\dbch\af31505\loch\f2 ed DDC01 for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1487,14 +1494,14 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \f2\fs18\insrsid6885713\charrsid6885713 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson" `
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England" `
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600" `
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "\hich\af2\dbch\af31505\loch\f2 +44 1753 276600" `
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, Lon\hich\af2\dbch\af31505\loch\f2 don, England for the Company Address.
+\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for \hich\af2\dbch\af31505\loch\f2 the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Compnay Phone.
 \par 
@@ -1503,14 +1510,14 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -Compa\hich\af2\dbch\af31505\loch\f2 nyName "Sherlock Holmes Consulting" 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting" 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson" `
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 r. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover \hich\af2\dbch\af31505\loch\f2 Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Compnay Email.
 \par 
 \par 
@@ -1520,20 +1527,22 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use al\hich\af2\dbch\af31505\loch\f2 l Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company\hich\af2\dbch\af31505\loch\f2 ="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster f\hich\af2\dbch\af31505\loch\f2 or the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format \hich\af2\dbch\af31505\loch\f2 of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2018 at 6PM is 2018-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2018-06-01_1800.docx
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 
+\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx
 \par 
 \par 
 \par 
@@ -1542,20 +1551,22 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -PDF -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all D\hich\af2\dbch\af31505\loch\f2 efault values and save the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = \hich\af2\dbch\af31505\loch\f2 Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date t\hich\af2\dbch\af31505\loch\f2 ime stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, 2018 at 6PM is 2018-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2018-06-01_1800.pdf
+\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 
+ at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9372083 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 
+\hich\af2\dbch\af31505\loch\f2 -06-01_1800.pdf
 \par 
 \par 
 \par 
@@ -1567,10 +1578,10 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1579,7 +1590,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Folder \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Folder \\\\FileServer\\ShareNam\hich\af2\dbch\af31505\loch\f2 e
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
@@ -1600,22 +1611,22 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer mail.domain.tld -From
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.\hich\af2\dbch\af31505\loch\f2 tld
+\par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover P\hich\af2\dbch\af31505\loch\f2 age format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will u\hich\af2\dbch\af31505\loch\f2 se the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
 \par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par \hich\af2\dbch\af31505\loch\f2     Script will use the default SMPTP port 25 and will not use SSL.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be\hich\af2\dbch\af31505\loch\f2  prompted
+\par \hich\af2\dbch\af31505\loch\f2     If the curre\hich\af2\dbch\af31505\loch\f2 nt user's credentials are not valid to send email, the user will be prompted
 \par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
 \par 
 \par 
@@ -1623,13 +1634,13 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 31 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid6885713\charrsid6885713 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@\hich\af2\dbch\af31505\loch\f2 CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     We\hich\af2\dbch\af31505\loch\f2 bster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1637,27 +1648,27 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@\hich\af2\dbch\af31505\loch\f2 carlwebster.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     Scr\hich\af2\dbch\af31505\loch\f2 ipt will use the email server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
-\par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     to enter \hich\af2\dbch\af31505\loch\f2 valid credentials.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 32 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 PS C:\\PSScript >.\\XD7_Inventory.ps1 -Section Policies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Section Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compan\hich\af2\dbch\af31505\loch\f2 y="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
 \par 
 \par 
@@ -1668,28 +1679,28 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Sof\hich\af2\dbch\af31505\loch\f2 tware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the C\hich\af2\dbch\af31505\loch\f2 over Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Set the followi\hich\af2\dbch\af31505\loch\f2 ng parameter values:
+\par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
-\par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs  \hich\af2\dbch\af31505\loch\f2    = True
+\par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
-\par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
+\par \hich\af2\dbch\af31505\loch\f2         S\hich\af2\dbch\af31505\loch\f2 ection             = "All"
 \par 
 \par 
 \par 
@@ -1699,8 +1710,8 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Dev -ScriptInfo -Log
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webs\hich\af2\dbch\af31505\loch\f2 ter" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\User\hich\af2\dbch\af31505\loch\f2 Info\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1708,11 +1719,11 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creat\hich\af2\dbch\af31505\loch\f2 es a text file named XAXDV1InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV1InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV1InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameter\hich\af2\dbch\af31505\loch\f2 s and other basic information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV1InventoryScriptInfo_yyyy-MM-dd_HHmm\hich\af2\dbch\af31505\loch\f2 .txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
 \par \hich\af2\dbch\af31505\loch\f2     XDV1DocScriptTranscript_yyyy-MM-dd_HHmm.txt.
@@ -1771,7 +1782,7 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
 6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
 656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
-{\*\latentstyles\lsdstimax377\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
+{\*\latentstyles\lsdstimax376\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 1;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 2;
@@ -1828,8 +1839,8 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 \lsdpriority49 \lsdlocked0 List Table 4 Accent 5;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 5;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 5;
 \lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
 \lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link Error;}}{\*\datastore 0105000002000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link;}}{\*\datastore 01050000
+02000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
 d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1838,8 +1849,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000020b1
-ef58307ad501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000000c3
+bea41ab5d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/XD7_Inventory_V1_ReadMe.rtf
+++ b/XD7_Inventory_V1_ReadMe.rtf
@@ -35,20 +35,20 @@
 {\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
 {\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}
 {\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
-\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\cfollowedhyperlink\ctint255\cshade255\red128\green0\blue128;\red43\green87\blue154;\red230\green230\blue230;\red54\green95\blue145;
-\red79\green129\blue189;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
-\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{
-\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat 
-heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
-\sbasedon0 \snext0 \slink16 \sqformat heading 2;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
+\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\cfollowedhyperlink\ctint255\cshade255\red128\green0\blue128;\red43\green87\blue154;
+\red230\green230\blue230;\red54\green95\blue145;\red79\green129\blue189;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }
+\noqfpromote {\stylesheet{\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 
+Normal;}{\s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
+\sbasedon0 \snext0 \slink15 \sqformat heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
+\fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink16 \sqformat heading 2;}{\*\cs10 \additive \ssemihidden \sunhideused \spriority1 Default Paragraph Font;}{\*
 \ts11\tsrowd\trftsWidthB3\trpaddl108\trpaddr108\trpaddfl3\trpaddft3\trpaddfb3\trpaddfr3\trcbpat1\trcfpat1\tblind0\tblindtype3\tsvertalt\tsbrdrt\tsbrdrl\tsbrdrb\tsbrdrr\tsbrdrdgl\tsbrdrdgr\tsbrdrh\tsbrdrv \ql \li0\ri0\sa200\sl276\slmult1
 \widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs22\alang1025 \ltrch\fcs0 \fs22\lang1033\langfe1033\loch\f31506\hich\af31506\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext11 \ssemihidden \sunhideused 
 Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\kerning32\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink1 \slocked \spriority9 Heading 1 Char;}{\*\cs16 \additive \rtlch\fcs1 \ab\ai\af0\afs28 \ltrch\fcs0 
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li720\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
-\sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf17 \sbasedon10 \styrsid16597410 FollowedHyperlink;}{\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 
+\sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\*\cs19 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \styrsid16597410 FollowedHyperlink;}{\s20\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 
 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext20 \sqformat \spriority1 \styrsid8394203 No Spacing;}{\*\cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 
-\cf18\chshdng0\chcfpat0\chcbpat19 \sbasedon10 \ssemihidden \sunhideused \styrsid15424297 Mention;}{\*\cs22 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf15\chshdng0\chcfpat0\chcbpat19 \sbasedon10 \ssemihidden \sunhideused \styrsid13663721 Unresolved Mention;}
+\cf20\chshdng0\chcfpat0\chcbpat21 \sbasedon10 \ssemihidden \sunhideused \styrsid15424297 Mention;}{\*\cs22 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf15\chshdng0\chcfpat0\chcbpat21 \sbasedon10 \ssemihidden \sunhideused \styrsid13663721 Unresolved Mention;}
 }{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 
 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }
 {\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel
@@ -76,20 +76,20 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1
 \lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}
 {\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid2070\rsid219208\rsid265763\rsid677819\rsid1076041\rsid1146462\rsid1654655\rsid2579094\rsid2584542\rsid2902416\rsid2978753
-\rsid3557177\rsid3761251\rsid3830441\rsid3831187\rsid4619633\rsid4925376\rsid5267713\rsid6053627\rsid6237392\rsid6258287\rsid6509366\rsid7367214\rsid7687390\rsid7746862\rsid7763859\rsid7809154\rsid7892821\rsid8394203\rsid8410782\rsid8473952\rsid8928184
-\rsid9112866\rsid9186743\rsid9380266\rsid9648170\rsid9986361\rsid10033903\rsid10638569\rsid11148983\rsid11353962\rsid11410367\rsid11488686\rsid11551746\rsid11809962\rsid12216897\rsid12801149\rsid13248665\rsid13308089\rsid13663721\rsid13853169\rsid13987238
-\rsid14298582\rsid14697282\rsid14881286\rsid15028178\rsid15424297\rsid15739805\rsid15757842\rsid15955795\rsid16207041\rsid16267726\rsid16269241\rsid16283129\rsid16408172\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0
-\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2018\mo4\dy16\hr6\min37}{\version41}{\edmins11757}{\nofpages25}{\nofwords8022}{\nofchars45731}
-{\nofcharsws53646}{\vern55}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid3557177\rsid3761251\rsid3830441\rsid3831187\rsid4619633\rsid4925376\rsid5267713\rsid6053627\rsid6237392\rsid6258287\rsid6509366\rsid6885713\rsid7367214\rsid7687390\rsid7746862\rsid7763859\rsid7809154\rsid7892821\rsid8394203\rsid8410782\rsid8473952
+\rsid8928184\rsid9112866\rsid9186743\rsid9380266\rsid9644665\rsid9648170\rsid9986361\rsid10033903\rsid10638569\rsid11148983\rsid11353962\rsid11410367\rsid11488686\rsid11551746\rsid11809962\rsid12216897\rsid12801149\rsid13248665\rsid13308089\rsid13663721
+\rsid13853169\rsid13987238\rsid14298582\rsid14697282\rsid14881286\rsid15028178\rsid15424297\rsid15739805\rsid15757842\rsid15955795\rsid16207041\rsid16267726\rsid16269241\rsid16283129\rsid16408172\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0
+\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster, Carl}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo10\dy3\hr16\min20}{\version43}{\edmins11763}{\nofpages27}{\nofwords8153}
+{\nofchars46473}{\nofcharsws54517}{\vern113}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MTQ3MDQzN7I0MTY0MDVQ0lEKTi0uzszPAykwrgUAVQ4iviwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Xen}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
-\b\fs28\cf20\insrsid16517051 \hich\af43\dbch\af31505\loch\f43 Desktop 7.x}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Version }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid16517051 
-\hich\af43\dbch\af31505\loch\f43 1}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf20\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Xen}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
+\b\fs28\cf22\insrsid16517051 \hich\af43\dbch\af31505\loch\f43 Desktop 7.x}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Version }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf22\insrsid16517051 
+\hich\af43\dbch\af31505\loch\f43 1}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \ab\af37\afs28 \ltrch\fcs0 \b\f37\fs28\insrsid11488686 
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid5267713 {\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37 NOTE: This script requires PowerShell V3 or later.
@@ -98,9 +98,9 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \par }{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37 NOTE: Word 2007 is no}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 \b\f37\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 t}{\rtlch\fcs1 \ab\af37 \ltrch\fcs0 
 \b\f37\insrsid5267713 \hich\af37\dbch\af31505\loch\f37  supported.}{\rtlch\fcs1 \af37 \ltrch\fcs0 \f37\insrsid5267713 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 The s\hich\af37\dbch\af31505\loch\f37 cript supports the following languages:
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 The script supports the following languages:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls1\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Catalan}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
@@ -118,11 +118,10 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Spanish
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af37\dbch\af31505\loch\f37 Swedish
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid9112866 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid9112866 
 \hich\af43\dbch\af31505\loch\f43 Prerequisites
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Before we can start using PowerShell to document anything in a Xe\hich\af37\dbch\af31505\loch\f37 
-nDesktop 7.x Site, let us ensure we have the necessary requirements.
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Before we can start using PowerShell to document anything in a XenDesktop 7.x Site, let us ensure we have the necessary requirements.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 If the script will be run remotely, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 there are two choices: install }{\rtlch\fcs1 
@@ -131,14 +130,14 @@ nDesktop 7.x Site, let us ensure we have the necessary requirements.
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid6258287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 Install Studio from the full XenDesktop 7.x installation media. }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 Installing Citrix Studio will install all the necessary PowerShell snapins.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 b.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 
-Install the PowerShell snapins individually.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Depending on the bitness of the computer, from the full XenDesktop 7\hich\af37\dbch\af31505\loch\f37 
-.x installation media, install the following files from either x64 or x86 (?? is either 86 or 64):}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 
+Install the PowerShell snapins individually.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Depending on the bitn\hich\af37\dbch\af31505\loch\f37 
+ess of the computer, from the full XenDesktop 7.x installation media, install the following files from either x64 or x86 (?? is either 86 or 64):}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\ADIdentity_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37 ii.\tab}\hich\af37\dbch\af31505\loch\f37 (Only for XenDesktop 7.6}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  and later}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37 ) }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 
-\hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\\hich\af37\dbch\af31505\loch\f37 Analytics_PowerShell_SnapIn_x??
+\hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Analytics_PowerShell_SnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Broker_PowerShell_SnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 iv.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
@@ -152,27 +151,27 @@ Install the PowerShell snapins individually.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 EnvTest_PowerShell_SnapIn_x??}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 viii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Host_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 ix.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Mac\hich\af37\dbch\af31505\loch\f37 
-hineCreation_PowerShellSnapIn_x??
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controlle\hich\af37\dbch\af31505\loch\f37 r\\
+Host_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 ix.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\MachineCreation_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 x.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Monitor_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xi.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Storefront_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xii.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Policy\\CitrixGroupPolicyManagement_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xii.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix P\hich\af37\dbch\af31505\loch\f37 olicy\\CitrixGroupPolicyManagement_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xiii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 DesktopStudio\\PxAppV_Studio\hich\af37\dbch\af31505\loch\f37 
-_PowershellSnapin_x??
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 DesktopStudio\\PxAppV_Studio_PowershellSnapin_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xiv.\tab}\hich\af37\dbch\af31505\loch\f37 Licensing\\LicensingAdmin_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Install the Citrix Group Policy PowerShell module.}{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  There are two options, download the module or copy the file from a Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  There are two options, download the module or copy the fil\hich\af37\dbch\af31505\loch\f37 e from a Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9112866 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 Download the file:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid1076041\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 In your Internet browser;
-\hich\af37\dbch\af31505\loch\f37  go to }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid1076041 {\*\datafield 
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid1076041\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 In your Internet browser; go to }
+{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid1076041\charrsid1076041 \hich\af37\dbch\af31505\loch\f37 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000020f7}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid1076041\charrsid1076041 \hich\af37\dbch\af31505\loch\f37 
 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041\charrsid1076041 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the file to your default download folder.}{
@@ -191,10 +190,10 @@ Current\\Utilities
 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 c.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
-If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid12801149 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 
-\hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
-\i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 
-, in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Cit\hich\af37\dbch\af31505\loch\f37 rix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+If you are running 32-bit or 64-bit Windows, copy the fi\hich\af37\dbch\af31505\loch\f37 le}{\rtlch\fcs1 \af0 \ltrch\fcs0 \i\insrsid9112866\charrsid12801149 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
+\i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 
+\ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\Modules}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
+\hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid9112866\charrsid12801149 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the computer where the script is run.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid8410782\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 If you are running 64-bit Windows, }{
@@ -206,19 +205,19 @@ If you are running 32-bit or 64-bit Windows, copy the file}{\rtlch\fcs1 \af0 \lt
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Note:}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  The Citrix.GroupPolicy.Commands.psm1 file is }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 not}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
- the version that comes with XenApp 6.5. This is an updated version that comes }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16207041 \hich\af37\dbch\af31505\loch\f37 installed with XenDesktop 7.x \hich\af37\dbch\af31505\loch\f37 or }{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
- HYPERLINK "http://support.citrix.com/article/CTX130147" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
+ the version that comes with XenApp 6.5. This is an updated version that comes }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16207041 \hich\af37\dbch\af31505\loch\f37 installed with XenDesktop 7.x or }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://\hich\af37\dbch\af31505\loch\f37 
+support.citrix.com/article/CTX130147" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000000000000000000000000080000800000000070000000003f00000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000000000000000000000000080000800000000070000000003f00000000006a}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 
 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2070 \hich\af37\dbch\af31505\loch\f37  }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is from Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
-\hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
-The updated version allows the policy cmdlets to be run against a remote Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 
+\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is fr\hich\af37\dbch\af31505\loch\f37 om Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
+\hich\af37\dbch\af31505\loch\f37 The updated version allows the policy cmdlets to be run against a remote Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 
  You cannot use the updated version to run against a remote XenApp 6.5 Collector.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9112866 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf21\insrsid16597410 \hich\af43\dbch\af31505\loch\f43 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9112866 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid16597410 \hich\af43\dbch\af31505\loch\f43 
 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid11488686 \hich\af43\dbch\af31505\loch\f43 How to use this script?
@@ -260,7 +259,7 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \i\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 -AdminAddress DDCName }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full \hich\af37\dbch\af31505\loch\f37 help text is available.
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\X}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 _Inventory.ps1 \hich\f37 \endash \loch\f37 full
 \par 
@@ -270,8 +269,8 @@ Help text}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11488686\charrsid7
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid14298582 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 PS C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14298582 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 > get-help .\\XD7_Inventory.ps1 -full
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \\\hich\af2\dbch\af31505\loch\f2 
+\par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid6885713 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 NAME
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
 XD7_Inventory.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
@@ -279,102 +278,99 @@ XD7_Inventory.ps1
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNTAX
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-MSWord] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-MachineCatal\hich\af2\dbch\af31505\loch\f2 ogs] [-MaxDetails] [-Policies] [-NoPolicies] [-NoADPolicies] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section <String>] [-Dev] }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-MSWord] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-Applicatio\hich\af2\dbch\af31505\loch\f2 ns] [-DeliveryGroups] [-DeliveryGroupsUtilization] 
+}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-MaxDetails] [-NoSessions] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <Strin\hich\af2\dbch\af31505\loch\f2 
+g>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory.ps1 [-AdminAddress <Strin\hich\af2\dbch\af31505\loch\f2 g>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-HTML] [-MSWord] }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-PDF] [-Text] [-Administrators] [-Applications] [-D\hich\af2\dbch\af31505\loch\f2 eliveryGroups] }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Logging] [-StartDate <DateTime>] [-EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hard\hich\af2\dbch\af31505\loch\f2 
-ware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 <String>] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL] -From <String> -To }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 <String> [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Compa\hich\af2\dbch\af31505\loch\f2 
+nyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-HTML] [-MSWord] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-PDF] [-Text] [-Administrators] [-Applications] [-DeliveryGroups] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-DeliveryGroupsUtilization] [-Hosting]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Logging] [-StartDate <DateTime>] [-EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-Machine\hich\af2\dbch\af31505\loch\f2 
+Catalogs] [-MaxDetails] [-NoSessions] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String>] -SmtpServer <String> [-SmtpPort <Int32>] [-UseSSL] -From <String> -To }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String> [-Dev] [-ScriptIn\hich\af2\dbch\af31505\loch\f2 fo] [-Log] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <String>] [-PDF] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-\hich\af2\dbch\af31505\loch\f2 Logging] [-StartDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-MaxDetails] [-Policies] [-NoPolicies] [-NoADPolicies] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section <String>] [-Dev] }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-ScriptInfo] [-Log] [<C\hich\af2\dbch\af31505\loch\f2 ommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory.ps1 [-AdminAddress <String>] [-CompanyAddress <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyEmail <String>] [-CompanyFax <String>] [-CompanyName <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-CompanyPhone <String>] [-CoverPage <String>] [-UserName <S\hich\af2\dbch\af31505\loch\f2 tring>] [-PDF] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Administrators] [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-MaxDetails] [-NoSessions] [-Policies] [-NoPolicies] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoADPolicies]\hich\af2\dbch\af31505\loch\f2 
+ [-StoreFront] [-AddDateTime] [-Folder <String>] [-Hardware] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 <String>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory.ps1 [-AdminAddress <String>] [-HTML] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-Dev] [-ScriptInfo] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [<CommonPara\hich\af2\dbch\af31505\loch\f2 meters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory.ps1 [-AdminAddress <String>] [-HTML] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [\hich\af2\dbch\af31505\loch\f2 
+-DeliveryGroupsUtilization] [-Hosting] [-Logging] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoSessions] [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Secti\hich\af2\dbch\af31505\loch\f2 on <String>] [-Dev] [-ScriptInfo] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateTime>] [-EndDate <DateTime>] [-MachineCatalogs] [\hich\af2\dbch\af31505\loch\f2 -MaxDetails] 
-}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] [-Folder }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 <String>] [-Hardware]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-Dev] [-ScriptInfo] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2 PSScript}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hosting] [-Logging] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-StartDate <DateT\hich\af2\dbch\af31505\loch\f2 ime>] [-EndDate <DateTime>] [-MachineCatalogs] [-MaxDetails] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-NoSessions] [-Policies] [-NoPolicies] [-NoADPolicies] [-StoreFront] [-AddDateTime] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Folder <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-Section <String>] [-Dev] [-ScriptInfo] [-Log] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 [<CommonParameters>]
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDes\hich\af2\dbch\af31505\loch\f2 ktop 7.0 through 7.7 Site using Microsoft
+\par \hich\af2\dbch\af31505\loch\f2 DESC\hich\af2\dbch\af31505\loch\f2 RIPTION
+\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.0 through 7.7 Site using Microsoft
 \par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This script requires at least PowerShell version 3 but runs best in version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   You do NOT have to run this script on a Controller. This script was developed and run
+\par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and r\hich\af2\dbch\af31505\loch\f2 un
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 8.1 VM.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the -AdminAddress (AA) parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This script supports versions of XenApp/XenDesktop from 7.\hich\af2\dbch\af31505\loch\f2 0 to 7.7.
+\par \hich\af2\dbch\af31505\loch\f2     This script supports versions of XenApp/XenDesktop from 7.0 to 7.7.
 \par \hich\af2\dbch\af31505\loch\f2     Version 7.8+ is a separate script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
+\par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary \hich\af2\dbch\af31505\loch\f2 information for:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
@@ -384,7 +380,7 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio for:
+\par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio\hich\af2\dbch\af31505\loch\f2  for:
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
@@ -392,31 +388,27 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrators] }{\rtlch\fc
 \par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
-\par \hich\af2\dbch\af31505\loch\f2         Sto\hich\af2\dbch\af31505\loch\f2 reFront
+\par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Complete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 and can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 C}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 
-omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 and can generate an extremely long report.
-
+\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     complete and can g\hich\af2\dbch\af31505\loch\f2 enerate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 take an}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 extremely long time to complete and generate an exceptionally long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
+\par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to complete and generate an exceptionally long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.x Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the X\hich\af2\dbch\af31505\loch\f2 enDesktop 7.x Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents and Footer.
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Danish
+\par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
-\par \hich\af2\dbch\af31505\loch\f2         Finnish
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
@@ -427,8 +419,8 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the\hich\af2\dbch\af31505\loch\f2  PowerShell snapins will connect }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 to.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShell snapins will connect
+\par \hich\af2\dbch\af31505\loch\f2         to.
 \par \hich\af2\dbch\af31505\loch\f2         This can be provided as a host name or an IP address.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to LocalHost.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
@@ -440,12 +432,12 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page,\hich\af2\dbch\af31505\loch\f2  if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010\hich\af2\dbch\af31505\loch\f2 )
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
@@ -453,53 +445,53 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the \hich\af2\dbch\af31505\loch\f2 MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard cha\hich\af2\dbch\af31505\loch\f2 racters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Page\hich\af2\dbch\af31505\loch\f2 s have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline \hich\af2\dbch\af31505\loch\f2 input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word \hich\af2\dbch\af31505\loch\f2 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Default value
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cove\hich\af2\dbch\af31505\loch\f2 r Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -507,72 +499,72 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the P\hich\af2\dbch\af31505\loch\f2 hone field.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <S\hich\af2\dbch\af31505\loch\f2 tring>
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alia\hich\af2\dbch\af31505\loch\f2 s of CPh.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
-\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
+\par \hich\af2\dbch\af31505\loch\f2         (default cover pages i\hich\af2\dbch\af31505\loch\f2 n Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't \hich\af2\dbch\af31505\loch\f2 work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in\hich\af2\dbch\af31505\loch\f2  2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 afte\hich\af2\dbch\af31505\loch\f2 r title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if yo\hich\af2\dbch\af31505\loch\f2 u like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (W\hich\af2\dbch\af31505\loch\f2 ord 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point\hich\af2\dbch\af31505\loch\f2 )
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2           Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually chan\hich\af2\dbch\af31505\loch\f2 ged to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; bo\hich\af2\dbch\af31505\loch\f2 x needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (\hich\af2\dbch\af31505\loch\f2 Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, wo\hich\af2\dbch\af31505\loch\f2 rks in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless change\hich\af2\dbch\af31505\loch\f2 d to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. \hich\af2\dbch\af31505\loch\f2 Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -581,51 +573,51 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alia\hich\af2\dbch\af31505\loch\f2 s of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?   \hich\af2\dbch\af31505\loch\f2                  false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input\hich\af2\dbch\af31505\loch\f2 ?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTM\hich\af2\dbch\af31505\loch\f2 L file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is \hich\af2\dbch\af31505\loch\f2 set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    name\hich\af2\dbch\af31505\loch\f2 d
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?\hich\af2\dbch\af31505\loch\f2   false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be ins\hich\af2\dbch\af31505\loch\f2 talled.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept \hich\af2\dbch\af31505\loch\f2 wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
-\par \hich\af2\dbch\af31505\loch\f2         Thi\hich\af2\dbch\af31505\loch\f2 s parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -633,37 +625,37 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -Administrators [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Administrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Admin\hich\af2\dbch\af31505\loch\f2 istrator Scopes and Roles.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Admins.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all ap\hich\af2\dbch\af31505\loch\f2 plications.
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an al\hich\af2\dbch\af31505\loch\f2 ias of Apps.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipelin\hich\af2\dbch\af31505\loch\f2 e input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all desktops in all Desktop (Delivery) Groups.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report \hich\af2\dbch\af31505\loch\f2 to take a very long
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        time to complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptiona\hich\af2\dbch\af31505\loch\f2 lly
-\par \hich\af2\dbch\af31505\loch\f2         long report.
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         long repo\hich\af2\dbch\af31505\loch\f2 rt.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
@@ -671,47 +663,46 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 days
-\par \hich\af2\dbch\af31505\loch\f2         depending on the information in \hich\af2\dbch\af31505\loch\f2 the database.
+\par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word and requires
+\par \hich\af2\dbch\af31505\loch\f2         This opt\hich\af2\dbch\af31505\loch\f2 ion is only available when the report is generated in Word and requires
 \par \hich\af2\dbch\af31505\loch\f2         Micosoft Excel to be locally installed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 time t\hich\af2\dbch\af31505\loch\f2 o}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 complete and generates a longer report.
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer
+\par \hich\af2\dbch\af31505\loch\f2         time to complete and generates a longer report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value              \hich\af2\dbch\af31505\loch\f2   False
+\par \hich\af2\dbch\af31505\loch\f2         Default value\hich\af2\dbch\af31505\loch\f2                 False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts, Host Connections and Resources.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by\hich\af2\dbch\af31505\loch\f2  default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  f\hich\af2\dbch\af31505\loch\f2 alse
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard char\hich\af2\dbch\af31505\loch\f2 acters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Logging [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by default, details for the previous }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 seven days.
+\par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by default, details for the previous
+\par \hich\af2\dbch\af31505\loch\f2         seven days.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position\hich\af2\dbch\af31505\loch\f2 ?                    named
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -719,26 +710,26 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2     -StartDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         Start date for the Configuration Logging report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Format \hich\af2\dbch\af31505\loch\f2 for date only is MM/DD/YYYY.
+\par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24 hour format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default is today's date minus seven days.
+\par \hich\af2\dbch\af31505\loch\f2         The default is\hich\af2\dbch\af31505\loch\f2  today's date minus seven days.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDays(-7))
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept\hich\af2\dbch\af31505\loch\f2  pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         End date for the Configuration Logging report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Format for date only is MM/DD/YYYY.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24 hour format.
+\par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/\hich\af2\dbch\af31505\loch\f2 YYYY HH:MM:SS" in 24 hour format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default is today's date.
@@ -746,25 +737,25 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -\hich\af2\dbch\af31505\loch\f2 displayhint date)
+\par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
+\par \hich\af2\dbch\af31505\loch\f2         Gives detai\hich\af2\dbch\af31505\loch\f2 led information for all machines in all Machine Catalogs.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalog\hich\af2\dbch\af31505\loch\f2 s parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      report to take an extremely long time to complete and generate an exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and \hich\af2\dbch\af31505\loch\f2 DeliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
 \par \hich\af2\dbch\af31505\loch\f2         long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Positio\hich\af2\dbch\af31505\loch\f2 n?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -772,20 +763,21 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is th\hich\af2\dbch\af31505\loch\f2 e same as using the following parameters:
+\par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
 \par \hich\af2\dbch\af31505\loch\f2                 Administrators
 \par \hich\af2\dbch\af31505\loch\f2                 Applications
 \par \hich\af2\dbch\af31505\loch\f2                 DeliveryGroups
 \par \hich\af2\dbch\af31505\loch\f2                 HardWare
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
-\par \hich\af2\dbch\af31505\loch\f2                 Logging
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Logging
 \par \hich\af2\dbch\af31505\loch\f2                 MachineCatalogs
-\par \hich\af2\dbch\af31505\loch\f2                 Po\hich\af2\dbch\af31505\loch\f2 licies
+\par \hich\af2\dbch\af31505\loch\f2                 Policies
 \par \hich\af2\dbch\af31505\loch\f2                 StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoADPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoSessions.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
+\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extrem\hich\af2\dbch\af31505\loch\f2 ely large report and
 \par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
@@ -793,21 +785,40 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pip\hich\af2\dbch\af31505\loch\f2 eline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -NoSessions [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Excludes Machine Catalog, Application and Hosting session data from the report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the MaxDetails parameter does not change this setting.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NS.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 efault value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Give detailed information for both Site and Citrix AD based Policies.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report to take a very long time
+\par \hich\af2\dbch\af31505\loch\f2         Note: The Citr\hich\af2\dbch\af31505\loch\f2 ix Group Policy PowerShell module will not load from an elevated
+\par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
+\par \hich\af2\dbch\af31505\loch\f2         If the module is manually imported, the module is not detected from an elevated
+\par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause\hich\af2\dbch\af31505\loch\f2  the report to take a very long time
 \par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         There are three related para\hich\af2\dbch\af31505\loch\f2 meters: Policies, NoPolicies and NoADPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies and NoADPolicies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is \hich\af2\dbch\af31505\loch\f2 given to NoPolicies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both Policies and NoADPolicies results in only policies created in Studio
-\par \hich\af2\dbch\af31505\loch\f2         being in the output\hich\af2\dbch\af31505\loch\f2  document.
+\par \hich\af2\dbch\af31505\loch\f2         being in the output document.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
@@ -815,28 +826,28 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  fa\hich\af2\dbch\af31505\loch\f2 lse
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD based policy information from the output document.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Pol\hich\af2\dbch\af31505\loch\f2 icies parameter to be set to False.
+\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to be set to False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is dis\hich\af2\dbch\af31505\loch\f2 abled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcar\hich\af2\dbch\af31505\loch\f2 d characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD based policy information from the output document.
-\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in S\hich\af2\dbch\af31505\loch\f2 tudio.
+\par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, where there may be thousands
+\par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, wh\hich\af2\dbch\af31505\loch\f2 ere there may be thousands
 \par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -862,22 +873,19 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 
-\hich\af2\dbch\af31505\loch\f2  at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 
--06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 
-\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   June 1, 2018 at 6PM is 2018-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2018-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the\hich\af2\dbch\af31505\loch\f2  optional output folder to save the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies t\hich\af2\dbch\af31505\loch\f2 he optional output folder to save the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -885,20 +893,18 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Hard\hich\af2\dbch\af31505\loch\f2 ware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Network}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Interface Cards
+\par \hich\af2\dbch\af31505\loch\f2     -Ha\hich\af2\dbch\af31505\loch\f2 rdware [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and
+\par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter may require the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an ac\hich\af2\dbch\af31505\loch\f2 count with permission to retrieve hardware information (i.e. Domain Admin }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 or}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Local Administrator).
+\par \hich\af2\dbch\af31505\loch\f2         using an a\hich\af2\dbch\af31505\loch\f2 ccount with permission to retrieve hardware information (i.e. Domain Admin
+\par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 size of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is d\hich\af2\dbch\af31505\loch\f2 isabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is di\hich\af2\dbch\af31505\loch\f2 sabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -911,25 +917,25 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Processes a specific section of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
-\par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications)
+\par \hich\af2\dbch\af31505\loch\f2                 Apps (Applic\hich\af2\dbch\af31505\loch\f2 ations)
 \par \hich\af2\dbch\af31505\loch\f2                 AppV
-\par \hich\af2\dbch\af31505\loch\f2               \hich\af2\dbch\af31505\loch\f2   Catalogs (Machine Catalogs)
+\par \hich\af2\dbch\af31505\loch\f2                 Catalogs (Machine Catalogs)
 \par \hich\af2\dbch\af31505\loch\f2                 Config (Configuration)
 \par \hich\af2\dbch\af31505\loch\f2                 Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Groups (Delivery Groups)
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
 \par \hich\af2\dbch\af31505\loch\f2                 Licensing
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
-\par \hich\af2\dbch\af31505\loch\f2                 Policies
-\par \hich\af2\dbch\af31505\loch\f2                 Sto\hich\af2\dbch\af31505\loch\f2 reFront
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2                Policies
+\par \hich\af2\dbch\af31505\loch\f2                 StoreFront
 \par \hich\af2\dbch\af31505\loch\f2                 Zones
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Notes:
 \par \hich\af2\dbch\af31505\loch\f2         Using Logging will force the Logging switch to True.
-\par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the Policies switch to True.
-\par \hich\af2\dbch\af31505\loch\f2         If Polici\hich\af2\dbch\af31505\loch\f2 es is selected and the NoPolicies switch is used, the script will terminate.
+\par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the\hich\af2\dbch\af31505\loch\f2  Policies switch to True.
+\par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies switch is used, the script will terminate.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -940,45 +946,45 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Required?              \hich\af2\dbch\af31505\loch\f2       true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Re\hich\af2\dbch\af31505\loch\f2 quired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value                25
+\par \hich\af2\dbch\af31505\loch\f2         Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whe\hich\af2\dbch\af31505\loch\f2 ther to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?\hich\af2\dbch\af31505\loch\f2                     false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the u\hich\af2\dbch\af31505\loch\f2 sername for the From email address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
+\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpSe\hich\af2\dbch\af31505\loch\f2 rver is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -986,9 +992,9 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the scr\hich\af2\dbch\af31505\loch\f2 ipt.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
@@ -996,26 +1002,26 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a t\hich\af2\dbch\af31505\loch\f2 ext file.
 \par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                 \hich\af2\dbch\af31505\loch\f2    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubles\hich\af2\dbch\af31505\loch\f2 hooting.
+\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1024,121 +1030,140 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      This cmdlet supports the common parameters: Verbose, Debug,
+\par \hich\af2\dbch\af31505\loch\f2         This cmdl\hich\af2\dbch\af31505\loch\f2 et supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.m\hich\af2\dbch\af31505\loch\f2 icrosoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/f\hich\af2\dbch\af31505\loch\f2 wlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
 \par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word, PDF
 \par \hich\af2\dbch\af31505\loch\f2     plain text or HTML document.
 \par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory.ps1
-\par \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16408172 \hich\af2\dbch\af31505\loch\f2       VERSION: 1.42}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 
+\par \hich\af2\dbch\af31505\loch\f2         VERS\hich\af2\dbch\af31505\loch\f2 ION: 1.44
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1076041 \hich\af2\dbch\af31505\loch\f2 April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16408172 \hich\af2\dbch\af31505\loch\f2 16}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid1076041 \hich\af2\dbch\af31505\loch\f2 , 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: October 3, 2019
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for t\hich\af2\dbch\af31505\loch\f2 he Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
+\par 
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Admi\hich\af2\dbch\af31505\loch\f2 nAddress DDC01
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will\hich\af2\dbch\af31505\loch\f2  use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Ad\hich\af2\dbch\af31505\loch\f2 ministrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl W\hich\af2\dbch\af31505\loch\f2 ebster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -PDF
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Will use all default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyN\hich\af2\dbch\af31505\loch\f2 ame="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the Use\hich\af2\dbch\af31505\loch\f2 r Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 4 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -TEXT
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKE\hich\af2\dbch\af31505\loch\f2 Y_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl \hich\af2\dbch\af31505\loch\f2 Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------------------\hich\af2\dbch\af31505\loch\f2 ------ EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -HTML
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\X\hich\af2\dbch\af31505\loch\f2 D7_Inventory.ps1 -HTML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 6 --------------------------
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USE\hich\af2\dbch\af31505\loch\f2 R\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURREN\hich\af2\dbch\af31505\loch\f2 T_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for\hich\af2\dbch\af31505\loch\f2  the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline\hich\af2\dbch\af31505\loch\f2  for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -DeliveryGroups
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Deskt\hich\af2\dbch\af31505\loch\f2 op (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in al\hich\af2\dbch\af31505\loch\f2 l Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1146,172 +1171,200 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
+\par 
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory\hich\af2\dbch\af31505\loch\f2 .ps1 -DeliveryGroupsUtilization
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory.ps1 -DeliveryGroupsUtilization
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilization details for all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------------\hich\af2\dbch\af31505\loch\f2 --- EXAMPLE 9 --------------------------
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ------------------\hich\af2\dbch\af31505\loch\f2 -------- EXAMPLE 9 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -DeliveryGroups -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs and
 \par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 10 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Applications
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a re\hich\af2\dbch\af31505\loch\f2 port with full details for all applications.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all applications.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl W\hich\af2\dbch\af31505\loch\f2 ebster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Com\hich\af2\dbch\af31505\loch\f2 mon\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_\hich\af2\dbch\af31505\loch\f2 Inventory.ps1 -Policies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Policies.
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -NoPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a rep\hich\af2\dbch\af31505\loch\f2 ort with no Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------------\hich\af2\dbch\af31505\loch\f2 --- EXAMPLE 13 --------------------------
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 13 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Adminis\hich\af2\dbch\af31505\loch\f2 trator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Administrator for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Policies -NoADPolicies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Site policies created in Studio but
-\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD\hich\af2\dbch\af31505\loch\f2  based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     no Citrix AD based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:\hich\af2\dbch\af31505\loch\f2 username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inve\hich\af2\dbch\af31505\loch\f2 ntory.ps1 -Administrators
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------\hich\af2\dbch\af31505\loch\f2 ------------- EXAMPLE 15 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Administrators
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Administrator Scopes and Roles.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE \hich\af2\dbch\af31505\loch\f2 16 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2  -EndDate 01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582\charrsid14298582 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the dates 01/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2  through
-\par \hich\af2\dbch\af31505\loch\f2     01/31/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 .
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default va\hich\af2\dbch\af31505\loch\f2 lues.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate 01/01/2018 -EndDate 01/31/2018
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Create\hich\af2\dbch\af31505\loch\f2 s a report with Configuration Logging details for the dates 01/01/2018 through
+\par \hich\af2\dbch\af31505\loch\f2     01/31/2018.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwar\hich\af2\dbch\af31505\loch\f2 e\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate "06/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 20\hich\af2\dbch\af31505\loch\f2 18}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2  10:00:00" -EndDate }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 "06/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2  14:00:00"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate "06/01/2018 10:00:00" -EndDate
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the time range
-\par \hich\af2\dbch\af31505\loch\f2     06/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 
- 10:00:00AM through 06/01/}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2  02:00:00PM.
+\par \hich\af2\dbch\af31505\loch\f2     "06/01/2018 14:00:00"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be e\hich\af2\dbch\af31505\loch\f2 ither 00 or 59.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the tim\hich\af2\dbch\af31505\loch\f2 e range
+\par \hich\af2\dbch\af31505\loch\f2     06/01/2018 10:00:00AM through 06/01/2018 02:00:00PM.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Com\hich\af2\dbch\af31505\loch\f2 panyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = \hich\af2\dbch\af31505\loch\f2 Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for th\hich\af2\dbch\af31505\loch\f2 e User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
@@ -1319,14 +1372,17 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Hosts, Host Connections and Resources.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\O\hich\af2\dbch\af31505\loch\f2 ffice\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Of\hich\af2\dbch\af31505\loch\f2 fice\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
@@ -1334,19 +1390,23 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     H\hich\af2\dbch\af31505\loch\f2 KEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------------------\hich\af2\dbch\af31505\loch\f2 -------- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MachineCatalogs -DeliveryGroups -Applications }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 -Policies -Hosting -StoreFront
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MachineCatalogs -DeliveryGroups -Applications
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Policies -Hosting -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machin\hich\af2\dbch\af31505\loch\f2 es in all Machine Catalogs
@@ -1356,93 +1416,135 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections and Resources
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Commo\hich\af2\dbch\af31505\loch\f2 n\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Commo\hich\af2\dbch\af31505\loch\f2 n\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Admin\hich\af2\dbch\af31505\loch\f2 istrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administra\hich\af2\dbch\af31505\loch\f2 tor for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MC -DG -Apps -Policies -Hosting
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
-\par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Cat\hich\af2\dbch\af31505\loch\f2 alogs
+\par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections and Resources
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_C\hich\af2\dbch\af31505\loch\f2 URRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713\charrsid6885713 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sidelin\hich\af2\dbch\af31505\loch\f2 e for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -\hich\af2\dbch\af31505\loch\f2 ------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Carl Webster Consulting" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Carl Webster Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713\charrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName\hich\af2\dbch\af31505\loch\f2  "Carl Webster" -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Con\hich\af2\dbch\af31505\loch\f2 sulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         Controller named DDC01 for the AdminAddress.
 \par 
+\par 
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScri\hich\af2\dbch\af31505\loch\f2 pt .\\XD7_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 "Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713\charrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
 \par \hich\af2\dbch\af31505\loch\f2         The computer running the script for the AdminAddress.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Sherlock Hol\hich\af2\dbch\af31505\loch\f2 mes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\dbch\af31505\loch\f2 `}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson" `
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ------------------------\hich\af2\dbch\af31505\loch\f2 -- EXAMPLE 24 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713\charrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson" `
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England" `
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600" `
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the \hich\af2\dbch\af31505\loch\f2 Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
+\par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, Lon\hich\af2\dbch\af31505\loch\f2 don, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Compnay Phone.
 \par 
+\par 
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting"`
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -Compa\hich\af2\dbch\af31505\loch\f2 nyName "Sherlock Holmes Consulting" 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson" `
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         D\hich\af2\dbch\af31505\loch\f2 r. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Compnay Email.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 26 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company\hich\af2\dbch\af31505\loch\f2 ="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format \hich\af2\dbch\af31505\loch\f2 of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2018 at 6PM is 2018-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2018-06-01_1800.docx
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -PDF -AddDateTime
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1452,122 +1554,114 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date t\hich\af2\dbch\af31505\loch\f2 ime stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 
-\hich\af2\dbch\af31505\loch\f2 -06-01_1800.docx
+\par \hich\af2\dbch\af31505\loch\f2     June 1, 2018 at 6PM is 2018-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2018-06-01_1800.pdf
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 27 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -PDF -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_U\hich\af2\dbch\af31505\loch\f2 SER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 
- at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9380266 \hich\af2\dbch\af31505\loch\f2 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 
-\hich\af2\dbch\af31505\loch\f2 -06-01_1800.pdf
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offic\hich\af2\dbch\af31505\loch\f2 e\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\Sha\hich\af2\dbch\af31505\loch\f2 reName
+\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 30 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer mail.domain.tld -From }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld -To ITGroup@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer mail.domain.tld -From
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.\hich\af2\dbch\af31505\loch\f2 tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\S\hich\af2\dbch\af31505\loch\f2 oftware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for th\hich\af2\dbch\af31505\loch\f2 e Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server mail.domain.tld, sending from }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "mailto:}{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid4619633\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\dbch\af31505\loch\f2 " }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid13248665 {\*\datafield 
-00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b4c0000006d00610069006c0074006f003a0058004400410064006d0069006e00400064006f006d00610069006e002e0074006c0064000000795881f43b1d7f48af2c825dc485276300000000a5ab000300000000fd70}
-}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4619633\charrsid4925376 \hich\af2\dbch\af31505\loch\f2 XDAdmin@domain.tld}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 , }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 sending to ITGroup@domain.tld.
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the default SMPTP port 25 and will not use SSL.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 to enter valid credentials.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 31 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587 }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
-\par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7746862 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com, sending to ITGroup@\hich\af2\dbch\af31505\loch\f2 carlwebster.com.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7746862 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 to enter valid credentials.
+\par \hich\af2\dbch\af31505\loch\f2     Script will u\hich\af2\dbch\af31505\loch\f2 se the email server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the default SMPTP port 25 and will not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be\hich\af2\dbch\af31505\loch\f2  prompted
+\par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 31 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6885713 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid6885713\charrsid6885713 
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@\hich\af2\dbch\af31505\loch\f2 CarlWebster.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Script will use the email server smtp.office365.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     webster@\hich\af2\dbch\af31505\loch\f2 carlwebster.com, sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
+\par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 32 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -S\hich\af2\dbch\af31505\loch\f2 ection Policies
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 PS C:\\PSScript >.\\XD7_Inventory.ps1 -Section Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7746862 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14298582\charrsid14298582 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compan\hich\af2\dbch\af31505\loch\f2 y="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
+\par 
+\par 
+\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 33 --------------------------
 \par 
@@ -1576,52 +1670,55 @@ omplete}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4619633 \hich\af2\db
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Com\hich\af2\dbch\af31505\loch\f2 mon\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
-\par \hich\af2\dbch\af31505\loch\f2         Administrators      \hich\af2\dbch\af31505\loch\f2 = True
+\par \hich\af2\dbch\af31505\loch\f2     Set the followi\hich\af2\dbch\af31505\loch\f2 ng parameter values:
+\par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
 \par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
-\par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
+\par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs  \hich\af2\dbch\af31505\loch\f2    = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
 \par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
 \par 
+\par 
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 34 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Dev -ScriptInfo -Log
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use a\hich\af2\dbch\af31505\loch\f2 ll Default values.
+\par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     Webs\hich\af2\dbch\af31505\loch\f2 ter" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster \hich\af2\dbch\af31505\loch\f2 for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV1InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     Creat\hich\af2\dbch\af31505\loch\f2 es a text file named XAXDV1InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creat\hich\af2\dbch\af31505\loch\f2 es a text file named XAXDV1InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV1InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameter\hich\af2\dbch\af31505\loch\f2 s and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
 \par \hich\af2\dbch\af31505\loch\f2     XDV1DocScriptTranscript_yyyy-MM-dd_HHmm.txt.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par 
+\par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
 \par }{\*\themedata 504b030414000600080000002100e9de0fbfff0000001c020000130000005b436f6e74656e745f54797065735d2e786d6cac91cb4ec3301045f748fc83e52d4a
 9cb2400825e982c78ec7a27cc0c8992416c9d8b2a755fbf74cd25442a820166c2cd933f79e3be372bd1f07b5c3989ca74aaff2422b24eb1b475da5df374fd9ad
 5689811a183c61a50f98f4babebc2837878049899a52a57be670674cb23d8e90721f90a4d2fa3802cb35762680fd800ecd7551dc18eb899138e3c943d7e503b6
@@ -1674,7 +1771,7 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 617020786d6c6e733a613d22687474703a2f2f736368656d61732e6f70656e786d6c666f726d6174732e6f72672f64726177696e676d6c2f323030362f6d6169
 6e22206267313d226c743122207478313d22646b3122206267323d226c743222207478323d22646b322220616363656e74313d22616363656e74312220616363
 656e74323d22616363656e74322220616363656e74333d22616363656e74332220616363656e74343d22616363656e74342220616363656e74353d22616363656e74352220616363656e74363d22616363656e74362220686c696e6b3d22686c696e6b2220666f6c486c696e6b3d22666f6c486c696e6b222f3e}
-{\*\latentstyles\lsdstimax375\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
+{\*\latentstyles\lsdstimax377\lsdlockeddef0\lsdsemihiddendef0\lsdunhideuseddef0\lsdqformatdef0\lsdprioritydef99{\lsdlockedexcept \lsdqformat1 \lsdpriority0 \lsdlocked0 Normal;\lsdqformat1 \lsdlocked0 heading 1;\lsdqformat1 \lsdlocked0 heading 2;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 3;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 4;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 5;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 6;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 7;\lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 8;
 \lsdsemihidden1 \lsdunhideused1 \lsdqformat1 \lsdpriority9 \lsdlocked0 heading 9;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 1;\lsdsemihidden1 \lsdunhideused1 \lsdpriority39 \lsdlocked0 toc 2;
@@ -1731,8 +1828,8 @@ a7e7c0000000360100000b00000000000000000000000000300100005f72656c732f2e72656c7350
 \lsdpriority49 \lsdlocked0 List Table 4 Accent 5;\lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 5;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 5;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 5;
 \lsdpriority46 \lsdlocked0 List Table 1 Light Accent 6;\lsdpriority47 \lsdlocked0 List Table 2 Accent 6;\lsdpriority48 \lsdlocked0 List Table 3 Accent 6;\lsdpriority49 \lsdlocked0 List Table 4 Accent 6;
 \lsdpriority50 \lsdlocked0 List Table 5 Dark Accent 6;\lsdpriority51 \lsdlocked0 List Table 6 Colorful Accent 6;\lsdpriority52 \lsdlocked0 List Table 7 Colorful Accent 6;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Mention;
-\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;}}{\*\datastore 010500000200000018000000
-4d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Hyperlink;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Hashtag;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Unresolved Mention;\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link;
+\lsdsemihidden1 \lsdunhideused1 \lsdlocked0 Smart Link Error;}}{\*\datastore 0105000002000000180000004d73786d6c322e534158584d4c5265616465722e362e3000000000000000000000060000
 d0cf11e0a1b11ae1000000000000000000000000000000003e000300feff090006000000000000000000000001000000010000000000000000100000feffffff00000000feffffff0000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
@@ -1741,8 +1838,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000090b6
-ab3b77d5d301feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000020b1
+ef58307ad501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/XD7_Script_ChangeLog.txt
+++ b/XD7_Script_ChangeLog.txt
@@ -3,6 +3,20 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
+#Version 1.44
+#	Add a NoSessions parameter to exclude Machine Catalog, Application and Hosting session data from the report
+#	Added missing "Will shutdown after use" to the Hosting section in Function OutputMachineDetails
+#	Updated Function CheckExcelPrereq to match the V2 script
+#	Updated Function CheckWordPrereq to match the V2 script
+#	Updated Function OutputDeliveryGroupDetails  by removing unused variable $xDeliveryGroupType
+#	Updated Function OutputDeliveryGroupUtilization to match the V2 script
+#	Updated Function OutputHosting to match the V2 script
+#	Updated Function OutputHostingSessions by removing all desktop code as it is not used
+#	Updated Function OutputNicItem with a $ComputerName parameter
+#		Updated Function GetComputerWMIInfo to pass the computer name parameter to the OutputNicItem function
+#	Updated Function ProcessCitrixPolicies to match the V2 script
+#	Updated Function ProcessHosting to match the V2 script
+
 #V1.43 21-Apr-2019
 #	If Policies parameter is used, check to see if PowerShell session is elevated. If it is,
 #		abort the script. This is the #2 support email.

--- a/XD7_Script_ChangeLog.txt
+++ b/XD7_Script_ChangeLog.txt
@@ -3,12 +3,17 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
-#Version 1.44
+#Version 1.44 17-Dec-2019
 #	Add a NoSessions parameter to exclude Machine Catalog, Application and Hosting session data from the report
 #	Added missing "Will shutdown after use" to the Hosting section in Function OutputMachineDetails
+#	Fix Swedish Table of Contents (Thanks to Johan Kallio)
+#		From 
+#			'sv-'	{ 'Automatisk innehållsförteckning2'; Break }
+#		To
+#			'sv-'	{ 'Automatisk innehållsförteckn2'; Break }
 #	Updated Function CheckExcelPrereq to match the V2 script
 #	Updated Function CheckWordPrereq to match the V2 script
-#	Updated Function OutputDeliveryGroupDetails  by removing unused variable $xDeliveryGroupType
+#	Updated Function OutputDeliveryGroupDetails by removing unused variable $xDeliveryGroupType
 #	Updated Function OutputDeliveryGroupUtilization to match the V2 script
 #	Updated Function OutputHosting to match the V2 script
 #	Updated Function OutputHostingSessions by removing all desktop code as it is not used
@@ -16,6 +21,7 @@
 #		Updated Function GetComputerWMIInfo to pass the computer name parameter to the OutputNicItem function
 #	Updated Function ProcessCitrixPolicies to match the V2 script
 #	Updated Function ProcessHosting to match the V2 script
+#	Updated help text
 
 #V1.43 21-Apr-2019
 #	If Policies parameter is used, check to see if PowerShell session is elevated. If it is,


### PR DESCRIPTION
#Version 1.44 17-Dec-2019
#	Add a NoSessions parameter to exclude Machine Catalog, Application and Hosting session data from the report
#	Added missing "Will shutdown after use" to the Hosting section in Function OutputMachineDetails
#	Fix Swedish Table of Contents (Thanks to Johan Kallio)
#		From 
#			'sv-'	{ 'Automatisk innehållsförteckning2'; Break }
#		To
#			'sv-'	{ 'Automatisk innehållsförteckn2'; Break }
#	Updated Function CheckExcelPrereq to match the V2 script
#	Updated Function CheckWordPrereq to match the V2 script
#	Updated Function OutputDeliveryGroupDetails by removing unused variable $xDeliveryGroupType
#	Updated Function OutputDeliveryGroupUtilization to match the V2 script
#	Updated Function OutputHosting to match the V2 script
#	Updated Function OutputHostingSessions by removing all desktop code as it is not used
#	Updated Function OutputNicItem with a $ComputerName parameter
#		Updated Function GetComputerWMIInfo to pass the computer name parameter to the OutputNicItem function
#	Updated Function ProcessCitrixPolicies to match the V2 script
#	Updated Function ProcessHosting to match the V2 script
#	Updated help text