### PR TITLE
Final update for 1.47

### DIFF
--- a/XD7_Inventory.ps1
+++ b/XD7_Inventory.ps1
@@ -948,9 +948,9 @@
 	plain text or HTML document.
 .NOTES
 	NAME: XD7_Inv5ntory.ps1
-	VERSION: 1.46
+	VERSION: 1.47
 	AUTHOR: Carl Webster
-	LASTEDIT: January 24, 2021
+	LASTEDIT: January 30, 2021
 #>
 
 #endregion
@@ -1130,6 +1130,14 @@ Param(
 
 # Version 1.0 released to the community on June 12, 2015
 
+#Version 1.47 30-Jan-2021
+#	Added getting hardware information for the license server when -Hardware is used
+#	Added getting hardware information for the SQL Server(s) when -Hardware is used
+#	Changed all Write-Verbose $(Get-Date) to add -Format G to put the dates in the user's locale
+#	Fixed duplicate item in the HTML output for Machine Catalogs
+#	Fixed wrong variable name when getting the Monitoring database mirroring information
+#	Updated the WMI query code for getting the Power Plan to handle the case where the Power Plan data is missing in the WMI repository
+#
 #Version 1.46 24-Jan-2021
 #	Added error checking in Function Check-NeededPSSnapins (Requested by Guy Leech)
 #	Added to the Computer Hardware section, the server's Power Plan
@@ -1499,50 +1507,50 @@ If($MSWord -eq $False -and $PDF -eq $False -and $Text -eq $False -and $HTML -eq 
 	$MSWord = $True
 }
 
-Write-Verbose "$(Get-Date): Testing output parameters"
+Write-Verbose "$(Get-Date -Format G): Testing output parameters"
 
 If($MSWord)
 {
-	Write-Verbose "$(Get-Date): MSWord is set"
+	Write-Verbose "$(Get-Date -Format G): MSWord is set"
 }
 ElseIf($PDF)
 {
-	Write-Verbose "$(Get-Date): PDF is set"
+	Write-Verbose "$(Get-Date -Format G): PDF is set"
 }
 ElseIf($Text)
 {
-	Write-Verbose "$(Get-Date): Text is set"
+	Write-Verbose "$(Get-Date -Format G): Text is set"
 }
 ElseIf($HTML)
 {
-	Write-Verbose "$(Get-Date): HTML is set"
+	Write-Verbose "$(Get-Date -Format G): HTML is set"
 }
 Else
 {
 	$ErrorActionPreference = $SaveEAPreference
-	Write-Verbose "$(Get-Date): Unable to determine output parameter"
+	Write-Verbose "$(Get-Date -Format G): Unable to determine output parameter"
 	If($Null -eq $MSWord)
 	{
-		Write-Verbose "$(Get-Date): MSWord is Null"
+		Write-Verbose "$(Get-Date -Format G): MSWord is Null"
 	}
 	ElseIf($Null -eq $PDF)
 	{
-		Write-Verbose "$(Get-Date): PDF is Null"
+		Write-Verbose "$(Get-Date -Format G): PDF is Null"
 	}
 	ElseIf($Null -eq $Text)
 	{
-		Write-Verbose "$(Get-Date): Text is Null"
+		Write-Verbose "$(Get-Date -Format G): Text is Null"
 	}
 	ElseIf($Null -eq $HTML)
 	{
-		Write-Verbose "$(Get-Date): HTML is Null"
+		Write-Verbose "$(Get-Date -Format G): HTML is Null"
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): MSWord is $($MSWord)"
-		Write-Verbose "$(Get-Date): PDF is $($PDF)"
-		Write-Verbose "$(Get-Date): Text is $($Text)"
-		Write-Verbose "$(Get-Date): HTML is $($HTML)"
+		Write-Verbose "$(Get-Date -Format G): MSWord is $($MSWord)"
+		Write-Verbose "$(Get-Date -Format G): PDF is $($PDF)"
+		Write-Verbose "$(Get-Date -Format G): Text is $($Text)"
+		Write-Verbose "$(Get-Date -Format G): HTML is $($HTML)"
 	}
 	Write-Error "
 	`n`n
@@ -1727,7 +1735,7 @@ If($ValidSection -eq $False)
 
 If($Folder -ne "")
 {
-	Write-Verbose "$(Get-Date): Testing folder path"
+	Write-Verbose "$(Get-Date -Format G): Testing folder path"
 	#does it exist
 	If(Test-Path $Folder -EA 0)
 	{
@@ -1735,7 +1743,7 @@ If($Folder -ne "")
 		If(Test-Path $Folder -pathType Container -EA 0)
 		{
 			#it exists and it is a folder
-			Write-Verbose "$(Get-Date): Folder path $Folder exists and is a folder"
+			Write-Verbose "$(Get-Date -Format G): Folder path $Folder exists and is a folder"
 		}
 		Else
 		{
@@ -1792,12 +1800,12 @@ If($Log)
 	try 
 	{
 		Start-Transcript -Path $Script:LogPath -Force -Verbose:$false | Out-Null
-		Write-Verbose "$(Get-Date): Transcript/log started at $Script:LogPath"
+		Write-Verbose "$(Get-Date -Format G): Transcript/log started at $Script:LogPath"
 		$Script:StartLog = $true
 	} 
 	catch 
 	{
-		Write-Verbose "$(Get-Date): Transcript/log failed at $Script:LogPath"
+		Write-Verbose "$(Get-Date -Format G): Transcript/log failed at $Script:LogPath"
 		$Script:StartLog = $false
 	}
 }
@@ -1817,19 +1825,19 @@ Function ElevatedSession
 
 	If($currentPrincipal.IsInRole( [Security.Principal.WindowsBuiltInRole]::Administrator ))
 	{
-		Write-Verbose "$(Get-Date): This is an elevated PowerShell session"
+		Write-Verbose "$(Get-Date -Format G): This is an elevated PowerShell session"
 		Return $True
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): This is NOT an elevated PowerShell session" -Foreground White
+		Write-Verbose "$(Get-Date -Format G): This is NOT an elevated PowerShell session" -Foreground White
 		Return $False
 	}
 }
 
 If($Policies -eq $True)
 {
-	Write-Verbose "$(Get-Date): Testing for elevated PowerShell session."
+	Write-Verbose "$(Get-Date -Format G): Testing for elevated PowerShell session."
 	#see if session is elevated
 	$Elevated = ElevatedSession
 	
@@ -1848,7 +1856,7 @@ If($Policies -eq $True)
 		Rerun the script from a non-elevated PowerShell session. The script will now close.
 		`n`n
 		"
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		Exit
 	}
 }
@@ -1861,7 +1869,7 @@ If($MSWord -or $PDF)
 {
 	#try and fix the issue with the $CompanyName variable
 	$Script:CoName = $CompanyName
-	Write-Verbose "$(Get-Date): CoName is $($Script:CoName)"
+	Write-Verbose "$(Get-Date -Format G): CoName is $($Script:CoName)"
 	
 	#the following values were attained from 
 	#http://groovy.codehaus.org/modules/scriptom/1.6.0/scriptom-office-2K3-tlb/apidocs/
@@ -1987,8 +1995,8 @@ Function GetComputerWMIInfo
 	# modified 29-Apr-2018 to change from Arrays to New-Object System.Collections.ArrayList
 
 	#Get Computer info
-	Write-Verbose "$(Get-Date): `t`tProcessing WMI Computer information"
-	Write-Verbose "$(Get-Date): `t`t`tHardware information"
+	Write-Verbose "$(Get-Date -Format G): `t`tProcessing WMI Computer information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tHardware information"
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 3 0 "Computer Information: $($RemoteComputerName)"
@@ -2030,7 +2038,7 @@ Function GetComputerWMIInfo
 	}
 	ElseIf(!$?)
 	{
-		Write-Verbose "$(Get-Date): Get-WmiObject win32_computersystem failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-WmiObject win32_computersystem failed for $($RemoteComputerName)"
 		Write-Warning "Get-WmiObject win32_computersystem failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
@@ -2057,7 +2065,7 @@ Function GetComputerWMIInfo
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for Computer information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for Computer information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for Computer information" "" $Null 0 $False $True
@@ -2073,7 +2081,7 @@ Function GetComputerWMIInfo
 	}
 	
 	#Get Disk info
-	Write-Verbose "$(Get-Date): `t`t`tDrive information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tDrive information"
 
 	If($MSWord -or $PDF)
 	{
@@ -2114,7 +2122,7 @@ Function GetComputerWMIInfo
 	}
 	ElseIf(!$?)
 	{
-		Write-Verbose "$(Get-Date): Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)"
 		Write-Warning "Get-WmiObject Win32_LogicalDisk failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
@@ -2140,7 +2148,7 @@ Function GetComputerWMIInfo
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for Drive information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for Drive information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for Drive information" "" $Null 0 $False $True
@@ -2157,7 +2165,7 @@ Function GetComputerWMIInfo
 	
 
 	#Get CPU's and stepping
-	Write-Verbose "$(Get-Date): `t`t`tProcessor information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tProcessor information"
 
 	If($MSWord -or $PDF)
 	{
@@ -2194,7 +2202,7 @@ Function GetComputerWMIInfo
 	}
 	ElseIf(!$?)
 	{
-		Write-Verbose "$(Get-Date): Get-WmiObject win32_Processor failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-WmiObject win32_Processor failed for $($RemoteComputerName)"
 		Write-Warning "Get-WmiObject win32_Processor failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
@@ -2220,7 +2228,7 @@ Function GetComputerWMIInfo
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for Processor information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for Processor information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for Processor information" "" $Null 0 $False $True
@@ -2236,7 +2244,7 @@ Function GetComputerWMIInfo
 	}
 
 	#Get Nics
-	Write-Verbose "$(Get-Date): `t`t`tNIC information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tNIC information"
 
 	If($MSWord -or $PDF)
 	{
@@ -2298,7 +2306,7 @@ Function GetComputerWMIInfo
 				ElseIf(!$?)
 				{
 					Write-Warning "$(Get-Date): Error retrieving NIC information"
-					Write-Verbose "$(Get-Date): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
+					Write-Verbose "$(Get-Date -Format G): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 					Write-Warning "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 					If($MSWORD -or $PDF)
 					{
@@ -2327,7 +2335,7 @@ Function GetComputerWMIInfo
 				}
 				Else
 				{
-					Write-Verbose "$(Get-Date): No results Returned for NIC information"
+					Write-Verbose "$(Get-Date -Format G): No results Returned for NIC information"
 					If($MSWORD -or $PDF)
 					{
 						WriteWordLine 0 2 "No results Returned for NIC information" "" $Null 0 $False $True
@@ -2347,7 +2355,7 @@ Function GetComputerWMIInfo
 	ElseIf(!$?)
 	{
 		Write-Warning "$(Get-Date): Error retrieving NIC configuration information"
-		Write-Verbose "$(Get-Date): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
+		Write-Verbose "$(Get-Date -Format G): Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 		Write-Warning "Get-WmiObject win32_networkadapterconfiguration failed for $($RemoteComputerName)"
 		If($MSWORD -or $PDF)
 		{
@@ -2376,7 +2384,7 @@ Function GetComputerWMIInfo
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): No results Returned for NIC configuration information"
+		Write-Verbose "$(Get-Date -Format G): No results Returned for NIC configuration information"
 		If($MSWORD -or $PDF)
 		{
 			WriteWordLine 0 2 "No results Returned for NIC configuration information" "" $Null 0 $False $True
@@ -2415,7 +2423,7 @@ Function OutputComputerItem
 	try 
 	{
 
-		$PowerPlan = (Get-WmiObject -ComputerName $RemoteComputerName -Class Win32_PowerPlan -Namespace "root\cimv2\power" |
+		$PowerPlan = (Get-WmiObject -ComputerName $RemoteComputerName -Class Win32_PowerPlan -Namespace "root\cimv2\power" -EA 0|
 			Where-Object {$_.IsActive -eq $true} |
 			Select-Object @{Name = "PowerPlan"; Expression = {$_.ElementName}}).PowerPlan
 	}
@@ -2423,7 +2431,7 @@ Function OutputComputerItem
 	catch 
 	{
 
-		$PowerPlan = $_.Exception
+		$PowerPlan = $_.Exception.Message
 
 	}	
 	
@@ -3662,10 +3670,10 @@ Function FindWordDocumentEnd
 
 Function SetupWord
 {
-	Write-Verbose "$(Get-Date): Setting up Word"
+	Write-Verbose "$(Get-Date -Format G): Setting up Word"
     
 	# Setup word for output
-	Write-Verbose "$(Get-Date): Create Word comObject."
+	Write-Verbose "$(Get-Date -Format G): Create Word comObject."
 	$Script:Word = New-Object -comobject "Word.Application" -EA 0 4>$Null
 	
 	If(!$? -or $Null -eq $Script:Word)
@@ -3684,7 +3692,7 @@ Function SetupWord
 		Exit
 	}
 
-	Write-Verbose "$(Get-Date): Determine Word language value"
+	Write-Verbose "$(Get-Date -Format G): Determine Word language value"
 	If( ( validStateProp $Script:Word Language Value__ ) )
 	{
 		[int]$Script:WordLanguageValue = [int]$Script:Word.Language.Value__
@@ -3708,7 +3716,7 @@ Function SetupWord
 		"
 		AbortScript
 	}
-	Write-Verbose "$(Get-Date): Word language value is $($Script:WordLanguageValue)"
+	Write-Verbose "$(Get-Date -Format G): Word language value is $($Script:WordLanguageValue)"
 	
 	$Script:WordCultureCode = GetCulture $Script:WordLanguageValue
 	
@@ -3775,7 +3783,7 @@ Function SetupWord
 	#only validate CompanyName if the field is blank
 	If([String]::IsNullOrEmpty($Script:CoName))
 	{
-		Write-Verbose "$(Get-Date): Company name is blank.  Retrieve company name from registry."
+		Write-Verbose "$(Get-Date -Format G): Company name is blank.  Retrieve company name from registry."
 		$TmpName = ValidateCompanyName
 		
 		If([String]::IsNullOrEmpty($TmpName))
@@ -3787,13 +3795,13 @@ Function SetupWord
 		Else
 		{
 			$Script:CoName = $TmpName
-			Write-Verbose "$(Get-Date): Updated company name to $($Script:CoName)"
+			Write-Verbose "$(Get-Date -Format G): Updated company name to $($Script:CoName)"
 		}
 	}
 
 	If($Script:WordCultureCode -ne "en-")
 	{
-		Write-Verbose "$(Get-Date): Check Default Cover Page for $($WordCultureCode)"
+		Write-Verbose "$(Get-Date -Format G): Check Default Cover Page for $($WordCultureCode)"
 		[bool]$CPChanged = $False
 		Switch ($Script:WordCultureCode)
 		{
@@ -3896,11 +3904,11 @@ Function SetupWord
 
 		If($CPChanged)
 		{
-			Write-Verbose "$(Get-Date): Changed Default Cover Page from Sideline to $($CoverPage)"
+			Write-Verbose "$(Get-Date -Format G): Changed Default Cover Page from Sideline to $($CoverPage)"
 		}
 	}
 
-	Write-Verbose "$(Get-Date): Validate cover page $($CoverPage) for culture code $($Script:WordCultureCode)"
+	Write-Verbose "$(Get-Date -Format G): Validate cover page $($CoverPage) for culture code $($Script:WordCultureCode)"
 	[bool]$ValidCP = $False
 	
 	$ValidCP = ValidateCoverPage $Script:WordVersion $CoverPage $Script:WordCultureCode
@@ -3908,8 +3916,8 @@ Function SetupWord
 	If(!$ValidCP)
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Verbose "$(Get-Date): Word language value $($Script:WordLanguageValue)"
-		Write-Verbose "$(Get-Date): Culture code $($Script:WordCultureCode)"
+		Write-Verbose "$(Get-Date -Format G): Word language value $($Script:WordLanguageValue)"
+		Write-Verbose "$(Get-Date -Format G): Culture code $($Script:WordCultureCode)"
 		Write-Error "
 		`n`n
 		`t`t
@@ -3928,7 +3936,7 @@ Function SetupWord
 
 	#http://jdhitsolutions.com/blog/2012/05/san-diego-2012-powershell-deep-dive-slides-and-demos/
 	#using Jeff's Demo-WordReport.ps1 file for examples
-	Write-Verbose "$(Get-Date): Load Word Templates"
+	Write-Verbose "$(Get-Date -Format G): Load Word Templates"
 
 	[bool]$Script:CoverPagesExist = $False
 	[bool]$BuildingBlocksExist = $False
@@ -3937,7 +3945,7 @@ Function SetupWord
 	#word 2010/2013/2016
 	$BuildingBlocksCollection = $Script:Word.Templates | Where-Object {$_.name -eq "Built-In Building Blocks.dotx"}
 
-	Write-Verbose "$(Get-Date): Attempt to load cover page $($CoverPage)"
+	Write-Verbose "$(Get-Date -Format G): Attempt to load cover page $($CoverPage)"
 	$part = $Null
 
 	$BuildingBlocksCollection | 
@@ -3970,16 +3978,16 @@ Function SetupWord
 
 	If(!$Script:CoverPagesExist)
 	{
-		Write-Verbose "$(Get-Date): Cover Pages are not installed or the Cover Page $($CoverPage) does not exist."
+		Write-Verbose "$(Get-Date -Format G): Cover Pages are not installed or the Cover Page $($CoverPage) does not exist."
 		Write-Warning "Cover Pages are not installed or the Cover Page $($CoverPage) does not exist."
 		Write-Warning "This report will not have a Cover Page."
 	}
 
-	Write-Verbose "$(Get-Date): Create empty word doc"
+	Write-Verbose "$(Get-Date -Format G): Create empty word doc"
 	$Script:Doc = $Script:Word.Documents.Add()
 	If($Null -eq $Script:Doc)
 	{
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Error "
 		`n`n
@@ -3996,7 +4004,7 @@ Function SetupWord
 	$Script:Selection = $Script:Word.Selection
 	If($Null -eq $Script:Selection)
 	{
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Error "
 		`n`n
@@ -4015,7 +4023,7 @@ Function SetupWord
 	$Script:Word.ActiveDocument.DefaultTabStop = 36
 
 	#Disable Spell and Grammar Check to resolve issue and improve performance (from Pat Coughlin)
-	Write-Verbose "$(Get-Date): Disable grammar and spell checking"
+	Write-Verbose "$(Get-Date -Format G): Disable grammar and spell checking"
 	#bug reported 1-Apr-2014 by Tim Mangan
 	#save current options first before turning them off
 	$Script:CurrentGrammarOption = $Script:Word.Options.CheckGrammarAsYouType
@@ -4026,17 +4034,17 @@ Function SetupWord
 	If($BuildingBlocksExist)
 	{
 		#insert new page, getting ready for table of contents
-		Write-Verbose "$(Get-Date): Insert new page, getting ready for table of contents"
+		Write-Verbose "$(Get-Date -Format G): Insert new page, getting ready for table of contents"
 		$part.Insert($Script:Selection.Range,$True) | Out-Null
 		$Script:Selection.InsertNewPage()
 
 		#table of contents
-		Write-Verbose "$(Get-Date): Table of Contents - $($Script:MyHash.Word_TableOfContents)"
+		Write-Verbose "$(Get-Date -Format G): Table of Contents - $($Script:MyHash.Word_TableOfContents)"
 		$toc = $BuildingBlocks.BuildingBlockEntries.Item($Script:MyHash.Word_TableOfContents)
 		If($Null -eq $toc)
 		{
-			Write-Verbose "$(Get-Date): "
-			Write-Verbose "$(Get-Date): Table of Content - $($Script:MyHash.Word_TableOfContents) could not be retrieved."
+			Write-Verbose "$(Get-Date -Format G): "
+			Write-Verbose "$(Get-Date -Format G): Table of Content - $($Script:MyHash.Word_TableOfContents) could not be retrieved."
 			Write-Warning "This report will not have a Table of Contents."
 		}
 		Else
@@ -4046,16 +4054,16 @@ Function SetupWord
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): Table of Contents are not installed."
+		Write-Verbose "$(Get-Date -Format G): Table of Contents are not installed."
 		Write-Warning "Table of Contents are not installed so this report will not have a Table of Contents."
 	}
 
 	#set the footer
-	Write-Verbose "$(Get-Date): Set the footer"
+	Write-Verbose "$(Get-Date -Format G): Set the footer"
 	[string]$footertext = "Report created by $username"
 
 	#get the footer
-	Write-Verbose "$(Get-Date): Get the footer and format font"
+	Write-Verbose "$(Get-Date -Format G): Get the footer and format font"
 	$Script:Doc.ActiveWindow.ActivePane.view.SeekView = $wdSeekPrimaryFooter
 	#get the footer and format font
 	$footers = $Script:Doc.Sections.Last.Footers
@@ -4069,15 +4077,15 @@ Function SetupWord
 			$footer.range.Font.Bold = $True
 		}
 	} #end ForEach
-	Write-Verbose "$(Get-Date): Footer text"
+	Write-Verbose "$(Get-Date -Format G): Footer text"
 	$Script:Selection.HeaderFooter.Range.Text = $footerText
 
 	#add page numbering
-	Write-Verbose "$(Get-Date): Add page numbering"
+	Write-Verbose "$(Get-Date -Format G): Add page numbering"
 	$Script:Selection.HeaderFooter.PageNumbers.Add($wdAlignPageNumberRight) | Out-Null
 
 	FindWordDocumentEnd
-	Write-Verbose "$(Get-Date):"
+	Write-Verbose "$(Get-Date -Format G):"
 	#end of Jeff Hicks 
 }
 
@@ -4090,7 +4098,7 @@ Function UpdateDocumentProperties
 	{
 		If($Script:CoverPagesExist)
 		{
-			Write-Verbose "$(Get-Date): Set Cover Page Properties"
+			Write-Verbose "$(Get-Date -Format G): Set Cover Page Properties"
 			#8-Jun-2017 put these 4 items in alpha order
             Set-DocumentProperty -Document $Script:Doc -DocProperty Author -Value $UserName
             Set-DocumentProperty -Document $Script:Doc -DocProperty Company -Value $Script:CoName
@@ -4142,7 +4150,7 @@ Function UpdateDocumentProperties
 			[string]$abstract = (Get-Date -Format d).ToString()
 			$ab.Text = $abstract
 
-			Write-Verbose "$(Get-Date): Update the Table of Contents"
+			Write-Verbose "$(Get-Date -Format G): Update the Table of Contents"
 			#update the Table of Contents
 			$Script:Doc.TablesOfContents.item(1).Update()
 			$cp = $Null
@@ -4869,7 +4877,7 @@ Function CheckHTMLColor
 
 Function SetupHTML
 {
-	Write-Verbose "$(Get-Date): Setting up HTML"
+	Write-Verbose "$(Get-Date -Format G): Setting up HTML"
 	If(!$AddDateTime)
 	{
 		[string]$Script:FileName1 = "$($Script:pwdpath)\$($OutputFileName).html"
@@ -5479,7 +5487,7 @@ Function SaveandCloseDocumentandShutdownWord
 	$Script:Word.Options.CheckGrammarAsYouType = $Script:CurrentGrammarOption
 	$Script:Word.Options.CheckSpellingAsYouType = $Script:CurrentSpellingOption
 
-	Write-Verbose "$(Get-Date): Save and Close document and Shutdown Word"
+	Write-Verbose "$(Get-Date -Format G): Save and Close document and Shutdown Word"
 	If($Script:WordVersion -eq $wdWord2010)
 	{
 		#the $saveFormat below passes StrictMode 2
@@ -5488,11 +5496,11 @@ Function SaveandCloseDocumentandShutdownWord
 		#http://msdn.microsoft.com/en-us/library/microsoft.office.interop.word.wdsaveformat(v=office.14).aspx
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Saving as DOCX file first before saving to PDF"
+			Write-Verbose "$(Get-Date -Format G): Saving as DOCX file first before saving to PDF"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): Saving DOCX file"
+			Write-Verbose "$(Get-Date -Format G): Saving DOCX file"
 		}
 		If($AddDateTime)
 		{
@@ -5502,12 +5510,12 @@ Function SaveandCloseDocumentandShutdownWord
 				$Script:FileName2 += "_$(Get-Date -f yyyy-MM-dd_HHmm).pdf"
 			}
 		}
-		Write-Verbose "$(Get-Date): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
+		Write-Verbose "$(Get-Date -Format G): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
 		$saveFormat = [Enum]::Parse([Microsoft.Office.Interop.Word.WdSaveFormat], "wdFormatDocumentDefault")
 		$Script:Doc.SaveAs([REF]$Script:FileName1, [ref]$SaveFormat)
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Now saving as PDF"
+			Write-Verbose "$(Get-Date -Format G): Now saving as PDF"
 			$saveFormat = [Enum]::Parse([Microsoft.Office.Interop.Word.WdSaveFormat], "wdFormatPDF")
 			$Script:Doc.SaveAs([REF]$Script:FileName2, [ref]$saveFormat)
 		}
@@ -5516,11 +5524,11 @@ Function SaveandCloseDocumentandShutdownWord
 	{
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Saving as DOCX file first before saving to PDF"
+			Write-Verbose "$(Get-Date -Format G): Saving as DOCX file first before saving to PDF"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): Saving DOCX file"
+			Write-Verbose "$(Get-Date -Format G): Saving DOCX file"
 		}
 		If($AddDateTime)
 		{
@@ -5530,16 +5538,16 @@ Function SaveandCloseDocumentandShutdownWord
 				$Script:FileName2 += "_$(Get-Date -f yyyy-MM-dd_HHmm).pdf"
 			}
 		}
-		Write-Verbose "$(Get-Date): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
+		Write-Verbose "$(Get-Date -Format G): Running $($Script:WordProduct) and detected operating system $($Script:RunningOS)"
 		$Script:Doc.SaveAs2([ref]$Script:FileName1, [ref]$wdFormatDocumentDefault)
 		If($PDF)
 		{
-			Write-Verbose "$(Get-Date): Now saving as PDF"
+			Write-Verbose "$(Get-Date -Format G): Now saving as PDF"
 			$Script:Doc.SaveAs([ref]$Script:FileName2, [ref]$wdFormatPDF)
 		}
 	}
 
-	Write-Verbose "$(Get-Date): Closing Word"
+	Write-Verbose "$(Get-Date -Format G): Closing Word"
 	$Script:Doc.Close()
 	$Script:Word.Quit()
 	If($PDF)
@@ -5550,7 +5558,7 @@ Function SaveandCloseDocumentandShutdownWord
 			$cnt++
 			If($cnt -gt 1)
 			{
-				Write-Verbose "$(Get-Date): Waiting another 10 seconds to allow Word to fully close (try # $($cnt))"
+				Write-Verbose "$(Get-Date -Format G): Waiting another 10 seconds to allow Word to fully close (try # $($cnt))"
 				Start-Sleep -Seconds 10
 				$Script:Word.Quit()
 				If($cnt -gt 2)
@@ -5564,16 +5572,16 @@ Function SaveandCloseDocumentandShutdownWord
 					$wordprocess = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}).Id
 					If($wordprocess -gt 0)
 					{
-						Write-Verbose "$(Get-Date): Attempting to stop WinWord process # $($wordprocess)"
+						Write-Verbose "$(Get-Date -Format G): Attempting to stop WinWord process # $($wordprocess)"
 						Stop-Process $wordprocess -EA 0
 					}
 				}
 			}
-			Write-Verbose "$(Get-Date): Attempting to delete $($Script:FileName1) since only $($Script:FileName2) is needed (try # $($cnt))"
+			Write-Verbose "$(Get-Date -Format G): Attempting to delete $($Script:FileName1) since only $($Script:FileName2) is needed (try # $($cnt))"
 			Remove-Item $Script:FileName1 -EA 0 4>$Null
 		}
 	}
-	Write-Verbose "$(Get-Date): System Cleanup"
+	Write-Verbose "$(Get-Date -Format G): System Cleanup"
 	[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
 	If(Test-Path variable:global:word)
 	{
@@ -5593,7 +5601,7 @@ Function SaveandCloseDocumentandShutdownWord
 	$wordprocess = ((Get-Process 'WinWord' -ea 0) | Where-Object {$_.SessionId -eq $SessionID}).Id
 	If($null -ne $wordprocess -and $wordprocess -gt 0)
 	{
-		Write-Verbose "$(Get-Date): WinWord process is still running. Attempting to stop WinWord process # $($wordprocess)"
+		Write-Verbose "$(Get-Date -Format G): WinWord process is still running. Attempting to stop WinWord process # $($wordprocess)"
 		Stop-Process $wordprocess -EA 0
 	}
 }
@@ -5683,7 +5691,7 @@ Function ProcessDocumentOutput
 	{
 		If(Test-Path "$($Script:FileName2)")
 		{
-			Write-Verbose "$(Get-Date): $($Script:FileName2) is ready for use"
+			Write-Verbose "$(Get-Date -Format G): $($Script:FileName2) is ready for use"
 			$GotFile = $True
 		}
 		Else
@@ -5696,7 +5704,7 @@ Function ProcessDocumentOutput
 	{
 		If(Test-Path "$($Script:FileName1)")
 		{
-			Write-Verbose "$(Get-Date): $($Script:FileName1) is ready for use"
+			Write-Verbose "$(Get-Date -Format G): $($Script:FileName1) is ready for use"
 			$GotFile = $True
 		}
 		Else
@@ -5723,81 +5731,81 @@ Function ProcessDocumentOutput
 
 Function ShowScriptOptions
 {
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): AddDateTime     : $($AddDateTime)"
-	Write-Verbose "$(Get-Date): AdminAddress    : $($AdminAddress)"
-	Write-Verbose "$(Get-Date): Administrators  : $($Administrators)"
-	Write-Verbose "$(Get-Date): Applications    : $($Applications)"
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): AddDateTime     : $($AddDateTime)"
+	Write-Verbose "$(Get-Date -Format G): AdminAddress    : $($AdminAddress)"
+	Write-Verbose "$(Get-Date -Format G): Administrators  : $($Administrators)"
+	Write-Verbose "$(Get-Date -Format G): Applications    : $($Applications)"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): Company Name    : $($Script:CoName)"
-		Write-Verbose "$(Get-Date): Company Address : $($CompanyAddress)"
-		Write-Verbose "$(Get-Date): Company Email   : $($CompanyEmail)"
-		Write-Verbose "$(Get-Date): Company Fax     : $($CompanyFax)"
-		Write-Verbose "$(Get-Date): Company Phone   : $($CompanyPhone)"
-		Write-Verbose "$(Get-Date): Cover Page      : $($CoverPage)"
+		Write-Verbose "$(Get-Date -Format G): Company Name    : $($Script:CoName)"
+		Write-Verbose "$(Get-Date -Format G): Company Address : $($CompanyAddress)"
+		Write-Verbose "$(Get-Date -Format G): Company Email   : $($CompanyEmail)"
+		Write-Verbose "$(Get-Date -Format G): Company Fax     : $($CompanyFax)"
+		Write-Verbose "$(Get-Date -Format G): Company Phone   : $($CompanyPhone)"
+		Write-Verbose "$(Get-Date -Format G): Cover Page      : $($CoverPage)"
 	}
-	Write-Verbose "$(Get-Date): DeliveryGroups  : $($DeliveryGroups)"
-	Write-Verbose "$(Get-Date): Dev             : $($Dev)"
+	Write-Verbose "$(Get-Date -Format G): DeliveryGroups  : $($DeliveryGroups)"
+	Write-Verbose "$(Get-Date -Format G): Dev             : $($Dev)"
 	If($Dev)
 	{
-		Write-Verbose "$(Get-Date): DevErrorFile    : $($Script:DevErrorFile)"
+		Write-Verbose "$(Get-Date -Format G): DevErrorFile    : $($Script:DevErrorFile)"
 	}
-	Write-Verbose "$(Get-Date): DGUtilization   : $($DeliveryGroupsUtilization)"
-	Write-Verbose "$(Get-Date): Filename1       : $($Script:Filename1)"
+	Write-Verbose "$(Get-Date -Format G): DGUtilization   : $($DeliveryGroupsUtilization)"
+	Write-Verbose "$(Get-Date -Format G): Filename1       : $($Script:Filename1)"
 	If($PDF)
 	{
-		Write-Verbose "$(Get-Date): Filename2       : $($Script:Filename2)"
+		Write-Verbose "$(Get-Date -Format G): Filename2       : $($Script:Filename2)"
 	}
-	Write-Verbose "$(Get-Date): Folder          : $($Folder)"
-	Write-Verbose "$(Get-Date): From            : $($From)"
-	Write-Verbose "$(Get-Date): Hosting         : $($Hosting)"
-	Write-Verbose "$(Get-Date): HW Inventory    : $($Hardware)"
-	Write-Verbose "$(Get-Date): Log             : $($Log)"
-	Write-Verbose "$(Get-Date): Logging         : $($Logging)"
+	Write-Verbose "$(Get-Date -Format G): Folder          : $($Folder)"
+	Write-Verbose "$(Get-Date -Format G): From            : $($From)"
+	Write-Verbose "$(Get-Date -Format G): Hosting         : $($Hosting)"
+	Write-Verbose "$(Get-Date -Format G): HW Inventory    : $($Hardware)"
+	Write-Verbose "$(Get-Date -Format G): Log             : $($Log)"
+	Write-Verbose "$(Get-Date -Format G): Logging         : $($Logging)"
 	If($Logging)
 	{
-		Write-Verbose "$(Get-Date):    Start Date   : $($StartDate)"
-		Write-Verbose "$(Get-Date):    End Date     : $($EndDate)"
+		Write-Verbose "$(Get-Date -Format G):    Start Date   : $($StartDate)"
+		Write-Verbose "$(Get-Date -Format G):    End Date     : $($EndDate)"
 	}
-	Write-Verbose "$(Get-Date): MachineCatalogs : $($MachineCatalogs)"
-	Write-Verbose "$(Get-Date): MaxDetails      : $($MaxDetails)"
-	Write-Verbose "$(Get-Date): NoADPolicies    : $($NoADPolicies)"
-	Write-Verbose "$(Get-Date): NoPolicies      : $($NoPolicies)"
-	Write-Verbose "$(Get-Date): Policies        : $($Policies)"
-	Write-Verbose "$(Get-Date): Save As HTML    : $($HTML)"
-	Write-Verbose "$(Get-Date): Save As PDF     : $($PDF)"
-	Write-Verbose "$(Get-Date): Save As TEXT    : $($TEXT)"
-	Write-Verbose "$(Get-Date): Save As WORD    : $($MSWORD)"
-	Write-Verbose "$(Get-Date): Section         : $($Section)"
-	Write-Verbose "$(Get-Date): ScriptInfo      : $($ScriptInfo)"
-	Write-Verbose "$(Get-Date): Site Name       : $($XDSiteName)"
-	Write-Verbose "$(Get-Date): Smtp Port       : $($SmtpPort)"
-	Write-Verbose "$(Get-Date): Smtp Server     : $($SmtpServer)"
-	Write-Verbose "$(Get-Date): StoreFront      : $($StoreFront)"
-	Write-Verbose "$(Get-Date): Title           : $($Script:Title)"
-	Write-Verbose "$(Get-Date): To              : $($To)"
-	Write-Verbose "$(Get-Date): Use SSL         : $($UseSSL)"
+	Write-Verbose "$(Get-Date -Format G): MachineCatalogs : $($MachineCatalogs)"
+	Write-Verbose "$(Get-Date -Format G): MaxDetails      : $($MaxDetails)"
+	Write-Verbose "$(Get-Date -Format G): NoADPolicies    : $($NoADPolicies)"
+	Write-Verbose "$(Get-Date -Format G): NoPolicies      : $($NoPolicies)"
+	Write-Verbose "$(Get-Date -Format G): Policies        : $($Policies)"
+	Write-Verbose "$(Get-Date -Format G): Save As HTML    : $($HTML)"
+	Write-Verbose "$(Get-Date -Format G): Save As PDF     : $($PDF)"
+	Write-Verbose "$(Get-Date -Format G): Save As TEXT    : $($TEXT)"
+	Write-Verbose "$(Get-Date -Format G): Save As WORD    : $($MSWORD)"
+	Write-Verbose "$(Get-Date -Format G): Section         : $($Section)"
+	Write-Verbose "$(Get-Date -Format G): ScriptInfo      : $($ScriptInfo)"
+	Write-Verbose "$(Get-Date -Format G): Site Name       : $($XDSiteName)"
+	Write-Verbose "$(Get-Date -Format G): Smtp Port       : $($SmtpPort)"
+	Write-Verbose "$(Get-Date -Format G): Smtp Server     : $($SmtpServer)"
+	Write-Verbose "$(Get-Date -Format G): StoreFront      : $($StoreFront)"
+	Write-Verbose "$(Get-Date -Format G): Title           : $($Script:Title)"
+	Write-Verbose "$(Get-Date -Format G): To              : $($To)"
+	Write-Verbose "$(Get-Date -Format G): Use SSL         : $($UseSSL)"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): User Name       : $($UserName)"
+		Write-Verbose "$(Get-Date -Format G): User Name       : $($UserName)"
 	}
-	Write-Verbose "$(Get-Date): XA/XD Version   : $($Script:XDSiteVersionReal)"
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): OS Detected     : $($Script:RunningOS)"
-	Write-Verbose "$(Get-Date): PoSH version    : $($Host.Version)"
-	Write-Verbose "$(Get-Date): PSCulture       : $($PSCulture)"
-	Write-Verbose "$(Get-Date): PSUICulture     : $($PSUICulture)"
+	Write-Verbose "$(Get-Date -Format G): XA/XD Version   : $($Script:XDSiteVersionReal)"
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): OS Detected     : $($Script:RunningOS)"
+	Write-Verbose "$(Get-Date -Format G): PoSH version    : $($Host.Version)"
+	Write-Verbose "$(Get-Date -Format G): PSCulture       : $($PSCulture)"
+	Write-Verbose "$(Get-Date -Format G): PSUICulture     : $($PSUICulture)"
 	If($MSWORD -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): Word language   : $($Script:WordLanguageValue)"
-		Write-Verbose "$(Get-Date): Word version    : $($Script:WordProduct)"
+		Write-Verbose "$(Get-Date -Format G): Word language   : $($Script:WordLanguageValue)"
+		Write-Verbose "$(Get-Date -Format G): Word version    : $($Script:WordProduct)"
 	}
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): Script start    : $($Script:StartTime)"
-	Write-Verbose "$(Get-Date): "
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): Script start    : $($Script:StartTime)"
+	Write-Verbose "$(Get-Date -Format G): "
+	Write-Verbose "$(Get-Date -Format G): "
 	
 	
 }
@@ -5807,7 +5815,7 @@ Function AbortScript
 	If($MSWord -or $PDF)
 	{
 		$Script:Word.quit()
-		Write-Verbose "$(Get-Date): System Cleanup"
+		Write-Verbose "$(Get-Date -Format G): System Cleanup"
 		[System.Runtime.Interopservices.Marshal]::ReleaseComObject($Script:Word) | Out-Null
 		If(Test-Path variable:global:word)
 		{
@@ -5816,7 +5824,7 @@ Function AbortScript
 	}
 	[gc]::collect() 
 	[gc]::WaitForPendingFinalizers()
-	Write-Verbose "$(Get-Date): Script has been aborted"
+	Write-Verbose "$(Get-Date -Format G): Script has been aborted"
 	$ErrorActionPreference = $SaveEAPreference
 	Exit
 }
@@ -5949,12 +5957,12 @@ Function TranscriptLogging
 			{
 				Start-Transcript -Path $Script:LogPath -Append -Verbose:$false | Out-Null
 			}
-			Write-Verbose "$(Get-Date): Transcript/log started at $Script:LogPath"
+			Write-Verbose "$(Get-Date -Format G): Transcript/log started at $Script:LogPath"
 			$Script:StartLog = $true
 		} 
 		catch 
 		{
-			Write-Verbose "$(Get-Date): Transcript/log failed at $Script:LogPath"
+			Write-Verbose "$(Get-Date -Format G): Transcript/log failed at $Script:LogPath"
 			$Script:StartLog = $false
 		}
 	}
@@ -5990,7 +5998,7 @@ Function Get-IPAddress
 Function SendEmail
 {
 	Param([array]$Attachments)
-	Write-Verbose "$(Get-Date): Prepare to email"
+	Write-Verbose "$(Get-Date -Format G): Prepare to email"
 
 	$emailAttachment = $Attachments
 	$emailSubject = $Script:Title
@@ -6030,13 +6038,13 @@ $Script:Title is attached.
 		
 		If($?)
 		{
-			Write-Verbose "$(Get-Date): Email successfully sent using anonymous credentials"
+			Write-Verbose "$(Get-Date -Format G): Email successfully sent using anonymous credentials"
 		}
 		ElseIf(!$?)
 		{
 			$e = $error[0]
 
-			Write-Verbose "$(Get-Date): Email was not sent:"
+			Write-Verbose "$(Get-Date -Format G): Email was not sent:"
 			Write-Warning "$(Get-Date): Exception: $e.Exception" 
 		}
 	}
@@ -6044,7 +6052,7 @@ $Script:Title is attached.
 	{
 		If($UseSSL)
 		{
-			Write-Verbose "$(Get-Date): Trying to send email using current user's credentials with SSL"
+			Write-Verbose "$(Get-Date -Format G): Trying to send email using current user's credentials with SSL"
 			Send-MailMessage -Attachments $emailAttachment -Body $emailBody -BodyAsHtml -From $From `
 			-Port $SmtpPort -SmtpServer $SmtpServer -Subject $emailSubject -To $To `
 			-UseSSL *>$Null
@@ -6064,7 +6072,7 @@ $Script:Title is attached.
 			If($null -ne $e.Exception -and $e.Exception.ToString().Contains("5.7"))
 			{
 				#The server response was: 5.7.xx SMTP; Client was not authenticated to send anonymous mail during MAIL FROM
-				Write-Verbose "$(Get-Date): Current user's credentials failed. Ask for usable credentials."
+				Write-Verbose "$(Get-Date -Format G): Current user's credentials failed. Ask for usable credentials."
 
 				If($Dev)
 				{
@@ -6090,19 +6098,19 @@ $Script:Title is attached.
 
 				If($?)
 				{
-					Write-Verbose "$(Get-Date): Email successfully sent using new credentials"
+					Write-Verbose "$(Get-Date -Format G): Email successfully sent using new credentials"
 				}
 				ElseIf(!$?)
 				{
 					$e = $error[0]
 
-					Write-Verbose "$(Get-Date): Email was not sent:"
+					Write-Verbose "$(Get-Date -Format G): Email was not sent:"
 					Write-Warning "$(Get-Date): Exception: $e.Exception" 
 				}
 			}
 			Else
 			{
-				Write-Verbose "$(Get-Date): Email was not sent:"
+				Write-Verbose "$(Get-Date -Format G): Email was not sent:"
 				Write-Warning "$(Get-Date): Exception: $e.Exception" 
 			}
 		}
@@ -6195,7 +6203,7 @@ Function GetAdmins
 #region Machine Catalog functions
 Function ProcessMachineCatalogs
 {
-	Write-Verbose "$(Get-Date): Retrieving Machine Catalogs"
+	Write-Verbose "$(Get-Date -Format G): Retrieving Machine Catalogs"
 
 	$txt = "Machine Catalogs"
 	If($MSWord -or $PDF)
@@ -6233,14 +6241,14 @@ Function ProcessMachineCatalogs
 		$txt = "Unable to retrieve Machine Catalogs"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputMachines
 {
 	Param([object]$Catalogs)
 	
-	Write-Verbose "$(Get-Date): `tProcessing Machine Catalogs"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Machine Catalogs"
 
 	#add 16-jun-2015, summary table of catalogs to match what is shown in Studio
 	If($MSWord -or $PDF)
@@ -6402,7 +6410,7 @@ Function OutputMachines
 	
 	ForEach($Catalog in $Catalogs)
 	{
-		Write-Verbose "$(Get-Date): `t`tAdding Catalog $($Catalog.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`tAdding Catalog $($Catalog.Name)"
 		$xType = ""
 		$xCatalogType = ""
 		$xAllocationType = ""
@@ -6807,10 +6815,10 @@ Function OutputMachines
 		{
 			WriteHTMLLine 2 0 "Machine Catalog: $($Catalog.Name)"
 			$rowdata = @()
-			$columnHeaders = @("Machine type",($htmlsilver -bor $htmlbold),$xCatalogType,$htmlwhite)
+			$columnHeaders = @("Description",($htmlsilver -bor $htmlbold),$Catalog.Description,$htmlwhite)
 			If($Catalog.ProvisioningType -eq "MCS")
 			{
-				$rowdata += @(,('Description',($htmlsilver -bor $htmlbold),$Catalog.Description,$htmlwhite))
+				$rowdata += @(,('Machine type',($htmlsilver -bor $htmlbold),$xCatalogType,$htmlwhite))
 				$rowdata += @(,('No. of machines',($htmlsilver -bor $htmlbold),$NumberOfMachines,$htmlwhite))
 				$rowdata += @(,('Allocated machines',($htmlsilver -bor $htmlbold),$Catalog.UsedCount,$htmlwhite))
 				$rowdata += @(,('Allocation type',($htmlsilver -bor $htmlbold),$xAllocationType,$htmlwhite))
@@ -6859,7 +6867,6 @@ Function OutputMachines
 			}
 			ElseIf($Catalog.ProvisioningType -eq "PVS")
 			{
-				$rowdata += @(,('Description',($htmlsilver -bor $htmlbold),$Catalog.Description,$htmlwhite))
 				$rowdata += @(,('Machine type',($htmlsilver -bor $htmlbold),$xCatalogType,$htmlwhite))
 				$rowdata += @(,('Provisioning method',($htmlsilver -bor $htmlbold),$xProvisioningType,$htmlwhite))
 				$rowdata += @(,('PVS address',($htmlsilver -bor $htmlbold),$Catalog.PvsAddress,$htmlwhite))
@@ -6884,7 +6891,7 @@ Function OutputMachines
 			}
 			ElseIf($Catalog.ProvisioningType -eq "Manual" -and $Catalog.IsRemotePC -eq $True)
 			{
-				$rowdata += @(,('Description',($htmlsilver -bor $htmlbold),$Catalog.Description,$htmlwhite))
+				$rowdata += @(,('Machine type',($htmlsilver -bor $htmlbold),$xCatalogType,$htmlwhite))
 				$rowdata += @(,('No. of machines',($htmlsilver -bor $htmlbold),$NumberOfMachines,$htmlwhite))
 				$rowdata += @(,('Allocated machines',($htmlsilver -bor $htmlbold),$Catalog.UsedCount,$htmlwhite))
 				$rowdata += @(,('Machine type',($htmlsilver -bor $htmlbold),$xCatalogType,$htmlwhite))
@@ -6908,7 +6915,7 @@ Function OutputMachines
 			}
 			ElseIf($Catalog.ProvisioningType -eq "Manual" -and $Catalog.IsRemotePC -ne $True)
 			{
-				$rowdata += @(,('Description',($htmlsilver -bor $htmlbold),$Catalog.Description,$htmlwhite))
+				$rowdata += @(,('Machine type',($htmlsilver -bor $htmlbold),$xCatalogType,$htmlwhite))
 				$rowdata += @(,('Organizational Units',($htmlsilver -bor $htmlbold),$RemotePCOU,$htmlwhite))
 				$rowdata += @(,('Allow subfolder matches',($htmlsilver -bor $htmlbold),$RemotePCSubOU,$htmlwhite))
 				$rowdata += @(,('No. of machines',($htmlsilver -bor $htmlbold),$NumberOfMachines,$htmlwhite))
@@ -7085,7 +7092,7 @@ Function OutputMachines
 		{
 			If($Null -ne $Machines)
 			{
-				Write-Verbose "$(Get-Date): `t`tProcessing Machines in $($Catalog.Name)"
+				Write-Verbose "$(Get-Date -Format G): `t`tProcessing Machines in $($Catalog.Name)"
 				
 				If($MSWord -or $PDF)
 				{
@@ -7152,7 +7159,7 @@ Function OutputMachines
 					WriteHTMLLine 0 0 " "
 				}
 				
-				Write-Verbose "$(Get-Date): `t`tProcessing administrators for Machines in $($Catalog.Name)"
+				Write-Verbose "$(Get-Date -Format G): `t`tProcessing administrators for Machines in $($Catalog.Name)"
 				$Admins = GetAdmins "Catalog" $Catalog.Name
 				
 				If($? -and ($Null -ne $Admins))
@@ -7192,7 +7199,7 @@ Function OutputMachineDetails
 {
 	Param([object] $Machine)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Desktop Machine $($Machine.HostedMachineName)"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Desktop Machine $($Machine.HostedMachineName)"
 	
 	$xAssociatedUserFullNames = @()
 	ForEach($Value in $Machine.AssociatedUserFullNames)
@@ -8001,7 +8008,7 @@ Function OutputServerMachineDetails
 {
 	Param([object] $Machine)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Server Machine $($Machine.HostedMachineName)"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Server Machine $($Machine.HostedMachineName)"
 	
 	$xAssociatedUserFullNames = @()
 	ForEach($Value in $Machine.AssociatedUserFullNames)
@@ -8778,7 +8785,7 @@ Function OutputServerMachineDetails
 #region Delivery Group functions
 Function ProcessDeliveryGroups
 {
-	Write-Verbose "$(Get-Date): Retrieving Delivery Groups"
+	Write-Verbose "$(Get-Date -Format G): Retrieving Delivery Groups"
 
 	If($MSWord -or $PDF)
 	{
@@ -8803,7 +8810,7 @@ Function ProcessDeliveryGroups
 
 	If($? -and ($Null -ne $AllDeliveryGroups))
 	{
-		Write-Verbose "$(Get-Date): `tProcessing Delivery Groups"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing Delivery Groups"
 		
 		#add 16-jun-2015, summary table of delivery groups to match what is shown in Studio
 		OutputDeliveryGroupTable $AllDeliveryGroups
@@ -8823,7 +8830,7 @@ Function ProcessDeliveryGroups
 		$txt = "Unable to retrieve Delivery Groups"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputDeliveryGroupTable 
@@ -8957,7 +8964,7 @@ Function OutputDeliveryGroup
 {
 	Param([object] $Group)
 	
-	Write-Verbose "$(Get-Date): `t`tAdding Delivery Group $($Group.Name)"
+	Write-Verbose "$(Get-Date -Format G): `t`tAdding Delivery Group $($Group.Name)"
 	$xSingleSession = ""
 	$xState = ""
 	If($Group.SessionSupport -eq "SingleSession")
@@ -9063,7 +9070,7 @@ Function OutputDeliveryGroup
 		$Machines = Get-BrokerMachine -DesktopGroupName $Group.name @XDParams2 -SortBy DNSName
 		If($? -and $Null -ne $Machines)
 		{
-			Write-Verbose "$(Get-Date): `t`tProcessing details"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing details"
 			$txt = "Delivery Group Details: "
 			If($MSWord -or $PDF)
 			{
@@ -9079,13 +9086,13 @@ Function OutputDeliveryGroup
 			}
 			OutputDeliveryGroupDetails $Group
 			
-			Write-Verbose "$(Get-Date): `t`tProcessing applications"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing applications"
 			OutputDeliveryGroupApplicationDetails $Group
 
-			Write-Verbose "$(Get-Date): `t`tProcessing machine catalogs"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing machine catalogs"
 			OutputDeliveryGroupCatalogs $Group
 
-			Write-Verbose "$(Get-Date): `t`tProcessing administrators"
+			Write-Verbose "$(Get-Date -Format G): `t`tProcessing administrators"
 			$Admins = GetAdmins "DesktopGroup" $Group.Name
 			
 			If($? -and ($Null -ne $Admins))
@@ -9129,7 +9136,7 @@ Function OutputDeliveryGroup
 	
 	If($DeliveryGroupsUtilization)
 	{
-		Write-Verbose "$(Get-Date): `t`t`tCreating Delivery Group Utilization report"
+		Write-Verbose "$(Get-Date -Format G): `t`t`tCreating Delivery Group Utilization report"
 		OutputDeliveryGroupUtilization $Group
 	}
 }
@@ -9146,7 +9153,7 @@ Function OutputDeliveryGroupUtilization
 	$txt = "Delivery Group Utilization Report"
 	If($MSWord -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): `t`t`tProcessing Utilization for $($Group.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`t`tProcessing Utilization for $($Group.Name)"
 		WriteWordLine 3 0 $txt
 		WriteWordLine 4 0 "Desktop Group Name: " $Group.Name
 
@@ -9211,10 +9218,10 @@ Function OutputDeliveryGroupUtilization
 		$Table = $Null
 		WriteWordLine 0 0 ""
 		
-		Write-Verbose "$(Get-Date): `t`t`tInitializing utilization chart for $($Group.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`t`tInitializing utilization chart for $($Group.Name)"
 
 		$TempFile =  "$($pwd)\emtempgraph_$(Get-Date -UFormat %Y%m%d_%H%M%S).csv"		
-		Write-Verbose "$(Get-Date): `t`t`tGetting utilization data for $($Group.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`t`tGetting utilization data for $($Group.Name)"
 		$Results = Get-BrokerDesktopUsage @XDParams2 -DesktopGroupName $Group.Name -SortBy Timestamp | Select-Object Timestamp, InUse
 
 		If($? -and $Null -ne $Results)
@@ -9235,7 +9242,7 @@ Function OutputDeliveryGroupUtilization
 			$excelCategoryScale = [Microsoft.Office.Interop.Excel.XlCategoryType]
 			$excelTickMark = [Microsoft.Office.Interop.Excel.XlTickMark]
 
-			Write-Verbose "$(Get-Date): `t`t`tOpening Excel with temp file $($TempFile)"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tOpening Excel with temp file $($TempFile)"
 
 			#Add CSV File into Excel Workbook 
 			$Null = $excel.Workbooks.Open($TempFile)
@@ -9248,7 +9255,7 @@ Function OutputDeliveryGroupUtilization
 			#$Start = @($selectionXL)[0].Text
 			#$End = @($selectionXL)[-1].Text
 
-			Write-Verbose "$(Get-Date): `t`t`tCreating chart for $($Group.Name)"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tCreating chart for $($Group.Name)"
 			$chart = $worksheet.Shapes.AddChart().Chart 
 
 			$chart.chartType = $excelChart::xlXYScatterLines
@@ -9274,7 +9281,7 @@ Function OutputDeliveryGroupUtilization
 			$worksheet.ChartObjects().Item(1).copy()
 			$word.Selection.PasteAndFormat(13)  #Pastes an Excel chart as a picture
 
-			Write-Verbose "$(Get-Date): `t`t`tClosing excel for $($Group.Name)"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tClosing excel for $($Group.Name)"
 			$excel.Workbooks.Close($false)
 			$excel.Quit()
 
@@ -9296,7 +9303,7 @@ Function OutputDeliveryGroupUtilization
 			$SessionID = (Get-Process -PID $PID).SessionId
 			(Get-Process 'Excel' -ea 0 | Where-Object {$_.sessionid -eq $Sessionid}) | Stop-Process 4>$Null
 			
-			Write-Verbose "$(Get-Date): `t`t`tDeleting temp files $($TempFile)"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tDeleting temp files $($TempFile)"
 			Remove-Item $TempFile *>$Null
 		}
 		ElseIf($? -and $Null -eq $Results)
@@ -9310,7 +9317,7 @@ Function OutputDeliveryGroupUtilization
 			OutputWarning $txt
 		}
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputDeliveryGroupDetails 
@@ -10795,11 +10802,11 @@ Function OutputDeliveryGroupApplicationDetails
 		{
 			If((Get-BrokerServiceAddedCapability) -contains "ApplicationFolders")
 			{
-				Write-Verbose "$(Get-Date): `t`tAdding Application $($Application.ApplicationName)"
+				Write-Verbose "$(Get-Date -Format G): `t`tAdding Application $($Application.ApplicationName)"
 			}
 			Else
 			{
-				Write-Verbose "$(Get-Date): `t`tAdding Application $($Application.Name)"
+				Write-Verbose "$(Get-Date -Format G): `t`tAdding Application $($Application.Name)"
 			}
 
 			$xEnabled = "Enabled"
@@ -10956,7 +10963,7 @@ Function OutputDeliveryGroupCatalogs
 
 		ForEach($MC in $MCs)
 		{
-			Write-Verbose "$(Get-Date): `t`t`tAdding catalog $($MC.CatalogName)"
+			Write-Verbose "$(Get-Date -Format G): `t`t`tAdding catalog $($MC.CatalogName)"
 
 			$Catalog = Get-BrokerCatalog @XDParams1 -Name $MC.CatalogName
 			If($? -and $Null -ne $Catalog)
@@ -11039,7 +11046,7 @@ Function OutputDeliveryGroupCatalogs
 #region process application functions
 Function ProcessApplications
 {
-	Write-Verbose "$(Get-Date): Retrieving Applications"
+	Write-Verbose "$(Get-Date -Format G): Retrieving Applications"
 	
 	$txt = "Applications"
 	If($MSWord -or $PDF)
@@ -11083,14 +11090,14 @@ Function ProcessApplications
 		$txt = "Unable to retrieve Applications"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputApplications
 {
 	Param([object]$AllApplications)
 	
-	Write-Verbose "$(Get-Date): `tProcessing Applications"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Applications"
 
 	If($MSWord -or $PDF)
 	{
@@ -11105,11 +11112,11 @@ Function OutputApplications
 	{
 		If((Get-BrokerServiceAddedCapability) -contains "ApplicationFolders")
 		{
-			Write-Verbose "$(Get-Date): `t`tAdding Application $($Application.ApplicationName)"
+			Write-Verbose "$(Get-Date -Format G): `t`tAdding Application $($Application.ApplicationName)"
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): `t`tAdding Application $($Application.Name)"
+			Write-Verbose "$(Get-Date -Format G): `t`tAdding Application $($Application.Name)"
 		}
 
 		$xEnabled = "Enabled"
@@ -11324,11 +11331,11 @@ Function OutputApplicationDetails
 	
 	If((Get-BrokerServiceAddedCapability) -contains "ApplicationFolders")
 	{
-		Write-Verbose "$(Get-Date): `t`tApplication details for $($Application.ApplicationName)"
+		Write-Verbose "$(Get-Date -Format G): `t`tApplication details for $($Application.ApplicationName)"
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): `t`tApplication details for $($Application.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`tApplication details for $($Application.Name)"
 	}
 	
 	$txt = "Details"
@@ -11695,7 +11702,7 @@ Function OutputApplicationSessions
 {
 	Param([object] $Application)
 	
-	Write-Verbose "$(Get-Date): `t`tApplication sessions for $($Application.BrowserName)"
+	Write-Verbose "$(Get-Date -Format G): `t`tApplication sessions for $($Application.BrowserName)"
 	$txt = "Sessions"
 	If($MSWord -or $PDF)
 	{
@@ -11845,11 +11852,11 @@ Function OutputApplicationAdministrators
 	
 	If((Get-BrokerServiceAddedCapability) -contains "ApplicationFolders")
 	{
-		Write-Verbose "$(Get-Date): `t`tApplication administrators for $($Application.ApplicationName)"
+		Write-Verbose "$(Get-Date -Format G): `t`tApplication administrators for $($Application.ApplicationName)"
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): `t`tApplication administrators for $($Application.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`tApplication administrators for $($Application.Name)"
 	}
 	
 	$txt = "Administrators"
@@ -12008,21 +12015,21 @@ Function ProcessPolicies
 		WriteHTMLLine 0 0 $txt1
 		WriteHTMLLine 0 0 $txt2
 	}
-	Write-Verbose "$(Get-Date): Processing XenDesktop Policies"
+	Write-Verbose "$(Get-Date -Format G): Processing XenDesktop Policies"
 	
 	ProcessPolicySummary 
 	
 	If($Policies)
 	{
 	
-		Write-Verbose "$(Get-Date): `tDoes localfarmgpo PSDrive already exist?"
+		Write-Verbose "$(Get-Date -Format G): `tDoes localfarmgpo PSDrive already exist?"
 		If(Get-PSDrive localfarmgpo -EA 0)
 		{
-			Write-Verbose "$(Get-Date): `tRemoving the current localfarmgpo PSDrive"
+			Write-Verbose "$(Get-Date -Format G): `tRemoving the current localfarmgpo PSDrive"
 			Remove-PSDrive localfarmgpo -EA 0 4>$Null
 		}
 		
-		Write-Verbose "$(Get-Date): Creating localfarmgpo PSDrive for Computer policies"
+		Write-Verbose "$(Get-Date -Format G): Creating localfarmgpo PSDrive for Computer policies"
 		New-PSDrive localfarmgpo -psprovider citrixgrouppolicy -root \ -controller $AdminAddress -Scope Global *>$Null
 		
 		#V1.40 using Citrix policy stuff and new-psdrive breaks transcript logging so restart transcript logging
@@ -12030,15 +12037,15 @@ Function ProcessPolicies
 		If(Get-PSDrive localfarmgpo -EA 0)
 		{
 			ProcessCitrixPolicies "localfarmgpo" "Computer"
-			Write-Verbose "$(Get-Date): Finished Processing Citrix Site Computer Policies"
-			Write-Verbose "$(Get-Date): "
+			Write-Verbose "$(Get-Date -Format G): Finished Processing Citrix Site Computer Policies"
+			Write-Verbose "$(Get-Date -Format G): "
 		}
 		Else
 		{
 			Write-Warning "Unable to create the LocalFarmGPO PSDrive on the XenDesktop Controller $($AdminAddress)"
 		}
 
-		Write-Verbose "$(Get-Date): Creating localfarmgpo PSDrive for User policies"
+		Write-Verbose "$(Get-Date -Format G): Creating localfarmgpo PSDrive for User policies"
 		New-PSDrive localfarmgpo -psprovider citrixgrouppolicy -root \ -controller $AdminAddress -Scope Global *>$Null
 		
 		#V1.40 using Citrix policy stuff and new-psdrive breaks transcript logging so restart transcript logging
@@ -12046,8 +12053,8 @@ Function ProcessPolicies
 		If(Get-PSDrive localfarmgpo -EA 0)
 		{
 			ProcessCitrixPolicies "localfarmgpo" "User"
-			Write-Verbose "$(Get-Date): Finished Processing Citrix Site User Policies"
-			Write-Verbose "$(Get-Date): "
+			Write-Verbose "$(Get-Date -Format G): Finished Processing Citrix Site User Policies"
+			Write-Verbose "$(Get-Date -Format G): "
 		}
 		Else
 		{
@@ -12061,34 +12068,34 @@ Function ProcessPolicies
 		Else
 		{
 			#thanks to the Citrix Engineering Team for helping me solve processing Citrix AD based Policies
-			Write-Verbose "$(Get-Date): "
-			Write-Verbose "$(Get-Date): `tSee if there are any Citrix AD based policies to process"
+			Write-Verbose "$(Get-Date -Format G): "
+			Write-Verbose "$(Get-Date -Format G): `tSee if there are any Citrix AD based policies to process"
 			$CtxGPOArray = @()
 			$CtxGPOArray = GetCtxGPOsInAD
 			If($CtxGPOArray -is [Array] -and $CtxGPOArray.Count -gt 0)
 			{
-				Write-Verbose "$(Get-Date): "
-				Write-Verbose "$(Get-Date): `tThere are $($CtxGPOArray.Count) Citrix AD based policies to process"
-				Write-Verbose "$(Get-Date): "
+				Write-Verbose "$(Get-Date -Format G): "
+				Write-Verbose "$(Get-Date -Format G): `tThere are $($CtxGPOArray.Count) Citrix AD based policies to process"
+				Write-Verbose "$(Get-Date -Format G): "
 
 				#V1.41 added -Property DisplayName
 				[array]$CtxGPOArray = $CtxGPOArray | Sort-Object -Property DisplayName -unique
 				
 				ForEach($CtxGPO in $CtxGPOArray)
 				{
-					Write-Verbose "$(Get-Date): `tCreating ADGpoDrv PSDrive for Computer Policies"
+					Write-Verbose "$(Get-Date -Format G): `tCreating ADGpoDrv PSDrive for Computer Policies"
 					New-PSDrive -Name ADGpoDrv -PSProvider CitrixGroupPolicy -Root \ -DomainGpo $($CtxGPO) -Scope Global *>$Null
 		
 					#V1.40 using Citrix policy stuff and new-psdrive breaks transcript logging so restart transcript logging
 					TranscriptLogging
 					If(Get-PSDrive ADGpoDrv -EA 0)
 					{
-						Write-Verbose "$(Get-Date): `tProcessing Citrix AD Policy $($CtxGPO)"
+						Write-Verbose "$(Get-Date -Format G): `tProcessing Citrix AD Policy $($CtxGPO)"
 					
-						Write-Verbose "$(Get-Date): `tRetrieving AD Policy $($CtxGPO)"
+						Write-Verbose "$(Get-Date -Format G): `tRetrieving AD Policy $($CtxGPO)"
 						ProcessCitrixPolicies "ADGpoDrv" "Computer"
-						Write-Verbose "$(Get-Date): Finished Processing Citrix AD Computer Policy $($CtxGPO)"
-						Write-Verbose "$(Get-Date): "
+						Write-Verbose "$(Get-Date -Format G): Finished Processing Citrix AD Computer Policy $($CtxGPO)"
+						Write-Verbose "$(Get-Date -Format G): "
 					}
 					Else
 					{
@@ -12096,19 +12103,19 @@ Function ProcessPolicies
 						Write-Warning "$($CtxGPO) was probably created by an updated Citrix Group Policy Provider"
 					}
 
-					Write-Verbose "$(Get-Date): `tCreating ADGpoDrv PSDrive for UserPolicies"
+					Write-Verbose "$(Get-Date -Format G): `tCreating ADGpoDrv PSDrive for UserPolicies"
 					New-PSDrive -Name ADGpoDrv -PSProvider CitrixGroupPolicy -Root \ -DomainGpo $($CtxGPO) -Scope Global *>$Null
 		
 					#V1.40 using Citrix policy stuff and new-psdrive breaks transcript logging so restart transcript logging
 					TranscriptLogging
 					If(Get-PSDrive ADGpoDrv -EA 0)
 					{
-						Write-Verbose "$(Get-Date): `tProcessing Citrix AD Policy $($CtxGPO)"
+						Write-Verbose "$(Get-Date -Format G): `tProcessing Citrix AD Policy $($CtxGPO)"
 					
-						Write-Verbose "$(Get-Date): `tRetrieving AD Policy $($CtxGPO)"
+						Write-Verbose "$(Get-Date -Format G): `tRetrieving AD Policy $($CtxGPO)"
 						ProcessCitrixPolicies "ADGpoDrv" "User"
-						Write-Verbose "$(Get-Date): Finished Processing Citrix AD User Policy $($CtxGPO)"
-						Write-Verbose "$(Get-Date): "
+						Write-Verbose "$(Get-Date -Format G): Finished Processing Citrix AD User Policy $($CtxGPO)"
+						Write-Verbose "$(Get-Date -Format G): "
 					}
 					Else
 					{
@@ -12116,30 +12123,30 @@ Function ProcessPolicies
 						Write-Warning "$($CtxGPO) was probably created by an updated Citrix Group Policy Provider"
 					}
 				}
-				Write-Verbose "$(Get-Date): Finished Processing Citrix AD Policies"
-				Write-Verbose "$(Get-Date): "
+				Write-Verbose "$(Get-Date -Format G): Finished Processing Citrix AD Policies"
+				Write-Verbose "$(Get-Date -Format G): "
 			}
 			Else
 			{
-				Write-Verbose "$(Get-Date): There are no Citrix AD based policies to process"
-				Write-Verbose "$(Get-Date): "
+				Write-Verbose "$(Get-Date -Format G): There are no Citrix AD based policies to process"
+				Write-Verbose "$(Get-Date -Format G): "
 			}
 		}
 	}
-	Write-Verbose "$(Get-Date): Finished Processing Citrix Policies"
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): Finished Processing Citrix Policies"
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function ProcessPolicySummary
 {
-	Write-Verbose "$(Get-Date): `tDoes localfarmgpo PSDrive already exist?"
+	Write-Verbose "$(Get-Date -Format G): `tDoes localfarmgpo PSDrive already exist?"
 	If(Get-PSDrive localfarmgpo -EA 0)
 	{
-		Write-Verbose "$(Get-Date): `tRemoving the current localfarmgpo PSDrive"
+		Write-Verbose "$(Get-Date -Format G): `tRemoving the current localfarmgpo PSDrive"
 		Remove-PSDrive localfarmgpo -EA 0 4>$Null
 	}
-	Write-Verbose "$(Get-Date): `tRetrieving Site Policies"
-	Write-Verbose "$(Get-Date): `t`tCreating localfarmgpo PSDrive"
+	Write-Verbose "$(Get-Date -Format G): `tRetrieving Site Policies"
+	Write-Verbose "$(Get-Date -Format G): `t`tCreating localfarmgpo PSDrive"
 	New-PSDrive localfarmgpo -psprovider citrixgrouppolicy -root \ -controller $AdminAddress -Scope Global *>$Null
 		
 	#V1.40 using Citrix policy stuff and new-psdrive breaks transcript logging so restart transcript logging
@@ -12164,38 +12171,38 @@ Function ProcessPolicySummary
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): "
-		Write-Verbose "$(Get-Date): See if there are any Citrix AD based policies to process"
+		Write-Verbose "$(Get-Date -Format G): "
+		Write-Verbose "$(Get-Date -Format G): See if there are any Citrix AD based policies to process"
 		$CtxGPOArray = @()
 		$CtxGPOArray = GetCtxGPOsInAD
 		If($CtxGPOArray -is [Array] -and $CtxGPOArray.Count -gt 0)
 		{
 			#V1.42 added -Property DisplayName
 			[array]$CtxGPOArray = $CtxGPOArray | Sort-Object -Property DisplayName -unique
-			Write-Verbose "$(Get-Date): "
-			Write-Verbose "$(Get-Date): `tThere are $($CtxGPOArray.Count) Citrix AD based policies to process"
-			Write-Verbose "$(Get-Date): "
+			Write-Verbose "$(Get-Date -Format G): "
+			Write-Verbose "$(Get-Date -Format G): `tThere are $($CtxGPOArray.Count) Citrix AD based policies to process"
+			Write-Verbose "$(Get-Date -Format G): "
 			
 			ForEach($CtxGPO in $CtxGPOArray)
 			{
-				Write-Verbose "$(Get-Date): `tCreating ADGpoDrv PSDrive"
+				Write-Verbose "$(Get-Date -Format G): `tCreating ADGpoDrv PSDrive"
 				New-PSDrive -Name ADGpoDrv -PSProvider CitrixGroupPolicy -Root \ -DomainGpo $($CtxGPO) -Scope "Global" *>$Null
 		
 				#V1.40 using Citrix policy stuff and new-psdrive breaks transcript logging so restart transcript logging
 				TranscriptLogging
 				If(Get-PSDrive ADGpoDrv -EA 0)
 				{
-					Write-Verbose "$(Get-Date): `tProcessing Citrix AD Policy $($CtxGPO)"
+					Write-Verbose "$(Get-Date -Format G): `tProcessing Citrix AD Policy $($CtxGPO)"
 				
-					Write-Verbose "$(Get-Date): `tRetrieving AD Policy $($CtxGPO)"
+					Write-Verbose "$(Get-Date -Format G): `tRetrieving AD Policy $($CtxGPO)"
 					$HDXPolicies = Get-CtxGroupPolicy -DriveName ADGpoDrv -EA 0 `
 					| Select-Object PolicyName, Type, Description, Enabled, Priority `
 					| Sort-Object Type, Priority
 			
 					OutputSummaryPolicyTable $HDXPolicies "AD" $CtxGPO
 					
-					Write-Verbose "$(Get-Date): Finished Processing Citrix AD Policy $($CtxGPO)"
-					Write-Verbose "$(Get-Date): "
+					Write-Verbose "$(Get-Date -Format G): Finished Processing Citrix AD Policy $($CtxGPO)"
+					Write-Verbose "$(Get-Date -Format G): "
 				}
 				Else
 				{
@@ -12204,13 +12211,13 @@ Function ProcessPolicySummary
 				}
 				Remove-PSDrive ADGpoDrv -EA 0 4>$Null
 			}
-			Write-Verbose "$(Get-Date): Finished Processing Citrix AD Policies"
-			Write-Verbose "$(Get-Date): "
+			Write-Verbose "$(Get-Date -Format G): Finished Processing Citrix AD Policies"
+			Write-Verbose "$(Get-Date -Format G): "
 		}
 		Else
 		{
-			Write-Verbose "$(Get-Date): There are no Citrix AD based policies to process"
-			Write-Verbose "$(Get-Date): "
+			Write-Verbose "$(Get-Date -Format G): There are no Citrix AD based policies to process"
+			Write-Verbose "$(Get-Date -Format G): "
 		}
 	}
 }
@@ -12254,7 +12261,7 @@ Function OutputSummaryPolicyTable
 
 	If($Null -ne $HDXPolicies)
 	{
-		Write-Verbose "$(Get-Date): `t`t`tPolicies"
+		Write-Verbose "$(Get-Date -Format G): `t`t`tPolicies"
 		If($MSWord -or $PDF)
 		{
 			[System.Collections.Hashtable[]] $PoliciesWordTable = @();
@@ -12379,7 +12386,7 @@ Function ProcessCitrixPolicies
 	Param([string]$xDriveName, [string]$xPolicyType)
 	#updated to match updates in the V2 script
 
-	Write-Verbose "$(Get-Date): `tRetrieving all $($xPolicyType) policy names"
+	Write-Verbose "$(Get-Date -Format G): `tRetrieving all $($xPolicyType) policy names"
 
 	$Script:TotalComputerPolicies = 0
 	$Script:TotalUserPolicies = 0
@@ -12434,7 +12441,7 @@ Function ProcessCitrixPolicies
 	{
 		ForEach($Policy in $Policies)
 		{
-			Write-Verbose "$(Get-Date): `tStarted $($Policy.PolicyName) "
+			Write-Verbose "$(Get-Date -Format G): `tStarted $($Policy.PolicyName) "
 			
 			If($xDriveName -eq "localfarmgpo")
 			{
@@ -12529,7 +12536,7 @@ Function ProcessCitrixPolicies
 			}
 				
 
-			Write-Verbose "$(Get-Date): `t`tRetrieving all filters"
+			Write-Verbose "$(Get-Date -Format G): `t`tRetrieving all filters"
 			$filters = Get-CtxGroupPolicyFilter -PolicyName $Policy.PolicyName `
 			-Type $xPolicyType `
 			-DriveName $xDriveName -EA 0 `
@@ -12539,7 +12546,7 @@ Function ProcessCitrixPolicies
 			{
 				If(![String]::IsNullOrEmpty($filters))
 				{
-					Write-Verbose "$(Get-Date): `t`tProcessing all filters"
+					Write-Verbose "$(Get-Date -Format G): `t`tProcessing all filters"
 					$txt = "Assigned to"
 					If($MSWord -or $PDF)
 					{
@@ -12719,7 +12726,7 @@ Function ProcessCitrixPolicies
 				}
 			}
 			
-			Write-Verbose "$(Get-Date): `t`tRetrieving all policy settings"
+			Write-Verbose "$(Get-Date -Format G): `t`tRetrieving all policy settings"
 			$Settings = Get-CtxGroupPolicyConfiguration -PolicyName $Policy.PolicyName `
 			-Type $Policy.Type `
 			-DriveName $xDriveName -EA 0
@@ -12756,8 +12763,8 @@ Function ProcessCitrixPolicies
 					}
 					$First = $False
 					
-					Write-Verbose "$(Get-Date): `t`tPolicy settings"
-					Write-Verbose "$(Get-Date): `t`t`tConnector for Configuration Manager 2012"
+					Write-Verbose "$(Get-Date -Format G): `t`tPolicy settings"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tConnector for Configuration Manager 2012"
 					If((validStateProp $Setting AdvanceWarningFrequency State ) -and ($Setting.AdvanceWarningFrequency.State -ne "NotConfigured"))
 					{
 						$txt = "Connector for Configuration Manager 2012\Advance warning frequency interval"
@@ -13124,7 +13131,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tICA"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA"
 					If((validStateProp $Setting ApplicationLaunchWaitTimeout State ) -and ($Setting.ApplicationLaunchWaitTimeout.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Application Launch Wait Timeout (milliseconds)"
@@ -13652,7 +13659,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tICA\Adobe Flash Delivery\Flash Redirection"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Adobe Flash Delivery\Flash Redirection"
 					If((validStateProp $Setting FlashAcceleration State ) -and ($Setting.FlashAcceleration.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Adobe Flash Delivery\Flash Redirection\Flash acceleration"
@@ -14139,7 +14146,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Audio"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Audio"
 					If((validStateProp $Setting AllowRtpAudio State ) -and ($Setting.AllowRtpAudio.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Audio\Audio over UDP real-time transport"
@@ -14256,7 +14263,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Auto Client Reconnect"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Auto Client Reconnect"
 					If((validStateProp $Setting AutoClientReconnect State ) -and ($Setting.AutoClientReconnect.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Auto Client Reconnect\Auto client reconnect"
@@ -14379,7 +14386,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tICA\Bandwidth"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Bandwidth"
 					If((validStateProp $Setting AudioBandwidthLimit State ) -and ($Setting.AudioBandwidthLimit.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Bandwidth\Audio redirection bandwidth limit (Kbps)"
@@ -14780,7 +14787,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Client Sensors\Location"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Client Sensors\Location"
 					If((validStateProp $Setting AllowLocationServices State ) -and ($Setting.AllowLocationServices.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Client Sensors\Location\Allow applications to use the physical location of the client device"
@@ -14803,7 +14810,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tICA\Desktop UI"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Desktop UI"
 					If((validStateProp $Setting AeroRedirection State ) -and ($Setting.AeroRedirection.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Desktop UI\Aero Redirection"
@@ -14931,7 +14938,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 			
-					Write-Verbose "$(Get-Date): `t`t`tICA\End User Monitoring"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\End User Monitoring"
 					If((validStateProp $Setting IcaRoundTripCalculation State ) -and ($Setting.IcaRoundTripCalculation.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\End User Monitoring\ICA round trip calculation"
@@ -14996,7 +15003,7 @@ Function ProcessCitrixPolicies
 						}	
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Enhanced Desktop Experience"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Enhanced Desktop Experience"
 					If((validStateProp $Setting EnhancedDesktopExperience State ) -and ($Setting.EnhancedDesktopExperience.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Enhanced Desktop Experience\Enhanced Desktop Experience"
@@ -15019,7 +15026,7 @@ Function ProcessCitrixPolicies
 						}	
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\File Redirection"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\File Redirection"
 					If((validStateProp $Setting AllowFileTransfer State ) -and ($Setting.AllowFileTransfer.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\File Redirection\Allow file transfer between desktop and client"
@@ -15336,7 +15343,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Graphics"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Graphics"
 					If((validStateProp $Setting AllowVisuallyLosslessCompression State ) -and ($Setting.AllowVisuallyLosslessCompression.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Graphics\Allow visually lossless compression"
@@ -15642,7 +15649,7 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Graphics\Caching"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Graphics\Caching"
 					If((validStateProp $Setting PersistentCache State ) -and ($Setting.PersistentCache.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Graphics\Caching\Persistent cache threshold (Kbps)"
@@ -15665,7 +15672,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Graphics\Framehawk"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Graphics\Framehawk"
 					If((validStateProp $Setting EnableFramehawkDisplayChannel State ) -and ($Setting.EnableFramehawkDisplayChannel.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Graphics\Framehawk\Framehawk display channel"
@@ -15709,7 +15716,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Keep Alive"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Keep Alive"
 					If((validStateProp $Setting IcaKeepAliveTimeout State ) -and ($Setting.IcaKeepAliveTimeout.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Keep Alive\ICA keep alive timeout (seconds)"
@@ -15761,7 +15768,7 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Local App Access"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Local App Access"
 					If((validStateProp $Setting AllowLocalAppAccess State ) -and ($Setting.AllowLocalAppAccess.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Local App Access\Allow local app access"
@@ -15948,7 +15955,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Mobile Experience"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Mobile Experience"
 					If((validStateProp $Setting AutoKeyboardPopUp State ) -and ($Setting.AutoKeyboardPopUp.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Mobile Experience\Automatic keyboard display"
@@ -16035,7 +16042,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tICA\Multimedia"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Multimedia"
 					If((validStateProp $Setting WebBrowserRedirection State ) -and ($Setting.WebBrowserRedirection.State -ne "NotConfigured"))
 					{
 						#V1.44
@@ -16544,7 +16551,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Multi-Stream Connections"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Multi-Stream Connections"
 					If((validStateProp $Setting UDPAudioOnServer State ) -and ($Setting.UDPAudioOnServer.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\MultiStream Connections\Audio over UDP"
@@ -16790,7 +16797,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Port Redirection"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Port Redirection"
 					If((validStateProp $Setting ClientComPortsAutoConnection State ) -and ($Setting.ClientComPortsAutoConnection.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Port Redirection\Auto connect client COM ports"
@@ -16876,7 +16883,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Printing"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Printing"
 					If((validStateProp $Setting ClientPrinterRedirection State ) -and ($Setting.ClientPrinterRedirection.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Printing\Client printer redirection"
@@ -17214,7 +17221,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Printing\Client Printers"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Printing\Client Printers"
 					If((validStateProp $Setting ClientPrinterAutoCreation State ) -and ($Setting.ClientPrinterAutoCreation.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Printing\Client Printers\Auto-create client printers"
@@ -17601,7 +17608,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Printing\Drivers"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Printing\Drivers"
 					If((validStateProp $Setting InboxDriverAutoInstallation State ) -and ($Setting.InboxDriverAutoInstallation.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Printing\Drivers\Automatic installation of in-box printer drivers"
@@ -17714,7 +17721,7 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tICA\Printing\Universal Print Server"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Printing\Universal Print Server"
 					If((validStateProp $Setting UpcSslCipherSuite State ) -and ($Setting.UpcSslCipherSuite.State -ne "NotConfigured"))
 					{
 						#V1.44
@@ -18092,7 +18099,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Printing\Universal Printing"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Printing\Universal Printing"
 					If((validStateProp $Setting EMFProcessingMode State ) -and ($Setting.EMFProcessingMode.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Printing\Universal Printing\Universal printing EMF processing mode"
@@ -18339,7 +18346,7 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Security"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Security"
 					If((validStateProp $Setting MinimumEncryptionLevel State ) -and ($Setting.MinimumEncryptionLevel.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Security\SecureICA minimum encryption level" 
@@ -18373,7 +18380,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Server Limits"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Server Limits"
 					If((validStateProp $Setting IdleTimerInterval State ) -and ($Setting.IdleTimerInterval.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Server Limits\Server idle timer interval (milliseconds)"
@@ -18396,7 +18403,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tICA\Session Limits"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Session Limits"
 					If((validStateProp $Setting SessionDisconnectTimer State ) -and ($Setting.SessionDisconnectTimer.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Session Limits\Disconnected session timer"
@@ -18524,7 +18531,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Session Watermark"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Session Watermark"
 					If((validStateProp $Setting EnableSessionWatermark State ) -and ($Setting.EnableSessionWatermark.State -ne "NotConfigured"))
 					{
 						#V1.44
@@ -18548,7 +18555,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Session Watermark\Watermark Content"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Session Watermark\Watermark Content"
 					If((validStateProp $Setting WatermarkIncludeClientIPAddress State ) -and ($Setting.WatermarkIncludeClientIPAddress.State -ne "NotConfigured"))
 					{
 						#V1.44
@@ -18682,7 +18689,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Session Watermark\Watermark Style"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Session Watermark\Watermark Style"
 					If((validStateProp $Setting WatermarkStyle State ) -and ($Setting.WatermarkStyle.State -ne "NotConfigured"))
 					{
 						#V1.44
@@ -18736,7 +18743,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Session Reliability"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Session Reliability"
 					If((validStateProp $Setting SessionReliabilityConnections State ) -and ($Setting.SessionReliabilityConnections.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Session Reliability\Session reliability connections"
@@ -18801,7 +18808,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Time Zone Control"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Time Zone Control"
 					If((validStateProp $Setting LocalTimeEstimation State ) -and ($Setting.LocalTimeEstimation.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Time Zone Control\Estimate local time for legacy clients"
@@ -18876,7 +18883,7 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\TWAIN Devices"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\TWAIN Devices"
 					If((validStateProp $Setting TwainRedirection State ) -and ($Setting.TwainRedirection.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\TWAIN devices\Client TWAIN device redirection"
@@ -18930,7 +18937,7 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Bidirectional Content Redirection"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Bidirectional Content Redirection"
 					If((validStateProp $Setting AllowURLRedirection State ) -and ($Setting.AllowURLRedirection.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Bidirectional Content Redirection\Allow Bidirectional Content Redirection"
@@ -19061,7 +19068,7 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\USB Devices"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\USB Devices"
 					If((validStateProp $Setting ClientUsbDeviceOptimizationRules State ) -and ($Setting.ClientUsbDeviceOptimizationRules.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\USB devices\Client USB device optimization rules"
@@ -19261,7 +19268,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Visual Display"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Visual Display"
 					If((validStateProp $Setting PreferredColorDepthForSimpleGraphics State ) -and ($Setting.PreferredColorDepthForSimpleGraphics.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Visual Display\Preferred color depth for simple graphics"
@@ -19344,7 +19351,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Visual Display\Moving Images"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Visual Display\Moving Images"
 					If((validStateProp $Setting MinimumAdaptiveDisplayJpegQuality State ) -and ($Setting.MinimumAdaptiveDisplayJpegQuality.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Visual Display\Moving Images\Minimum image quality"
@@ -19476,7 +19483,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\Visual Display\Still Images"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\Visual Display\Still Images"
 					If((validStateProp $Setting ExtraColorCompression State ) -and ($Setting.ExtraColorCompression.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\Visual Display\Still Images\Extra Color Compression"
@@ -19594,7 +19601,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tICA\WebSockets"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tICA\WebSockets"
 					If((validStateProp $Setting AcceptWebSocketsConnections State ) -and ($Setting.AcceptWebSocketsConnections.State -ne "NotConfigured"))
 					{
 						$txt = "ICA\WebSockets\WebSocket connections"
@@ -19692,7 +19699,7 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tLoad Management"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tLoad Management"
 					If((validStateProp $Setting ConcurrentLogonsTolerance State ) -and ($Setting.ConcurrentLogonsTolerance.State -ne "NotConfigured"))
 					{
 						$txt = "Load Management\Concurrent logons tolerance"
@@ -19981,8 +19988,8 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management"
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Advanced settings"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Advanced settings"
 					If((validStateProp $Setting CEIPEnabled State ) -and ($Setting.CEIPEnabled.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Advanced settings\Customer Experience Improvement Program"
@@ -20133,7 +20140,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Basic settings"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Basic settings"
 					If((validStateProp $Setting PSMidSessionWriteBack State ) -and ($Setting.PSMidSessionWriteBack.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Basic settings\Active write back"
@@ -20531,9 +20538,9 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Citrix Virtual Apps Optimization settings"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Citrix Virtual Apps Optimization settings"
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Cross-Platform settings"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Cross-Platform settings"
 					If((validStateProp $Setting CPUserGroups_Part State ) -and ($Setting.CPUserGroups_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Cross-Platform settings\Cross-platform settings user groups"
@@ -20766,7 +20773,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\File system"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\File system"
 					#V1.44
 					If((validStateProp $Setting LogonExclusionCheck_Part State ) -and ($Setting.LogonExclusionCheck_Part.State -ne "NotConfigured"))
 					{
@@ -20797,7 +20804,7 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $tmp 
 						}
 					}
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\File system\Default Exclusions"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\File system\Default Exclusions"
 					If((validStateProp $Setting DefaultExclusionListSyncDir State ) -and ($Setting.DefaultExclusionListSyncDir.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\File system\Default Exclusions\Enable Default Exclusion List - directories"
@@ -21451,7 +21458,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\File system\Exclusions"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\File system\Exclusions"
 					If((validStateProp $Setting ExclusionListSyncDir_Part State ) -and ($Setting.ExclusionListSyncDir_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\File system\Exclusions\Exclusion list - directories"
@@ -21655,7 +21662,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\File system\Synchronization"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\File system\Synchronization"
 					If((validStateProp $Setting SyncDirList_Part State ) -and ($Setting.SyncDirList_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\File system\Synchronization\Directories to synchronize"
@@ -22061,8 +22068,8 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection"
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\AppData(Roaming)"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\AppData(Roaming)"
 					If((validStateProp $Setting FRAppDataPath_Part State ) -and ($Setting.FRAppDataPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\AppData(Roaming)\AppData(Roaming) path"
@@ -22135,7 +22142,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Common settings"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Common settings"
 					If((validStateProp $Setting FRAdminAccess_Part State ) -and ($Setting.FRAdminAccess_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Common settings\Grant administrator access"
@@ -22179,7 +22186,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Contacts"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Contacts"
 					If((validStateProp $Setting FRContactsPath_Part State ) -and ($Setting.FRContactsPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Contacts\Contacts path"
@@ -22252,7 +22259,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Desktop"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Desktop"
 					If((validStateProp $Setting FRDesktopPath_Part State ) -and ($Setting.FRDesktopPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Desktop\Desktop path"
@@ -22325,7 +22332,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Documents"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Documents"
 					If((validStateProp $Setting FRDocumentsPath_Part State ) -and ($Setting.FRDocumentsPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Documents\Documents path"
@@ -22399,7 +22406,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Downloads"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Downloads"
 					If((validStateProp $Setting FRDownloadsPath_Part State ) -and ($Setting.FRDownloadsPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Downloads\Downloads path"
@@ -22472,7 +22479,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Favorites"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Favorites"
 					If((validStateProp $Setting FRFavoritesPath_Part State ) -and ($Setting.FRFavoritesPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Favorites\Favorites path"
@@ -22545,7 +22552,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Links"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Links"
 					If((validStateProp $Setting FRLinksPath_Part State ) -and ($Setting.FRLinksPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Links\Links path"
@@ -22618,7 +22625,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Music"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Music"
 					If((validStateProp $Setting FRMusicPath_Part State ) -and ($Setting.FRMusicPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Music\Music path"
@@ -22692,7 +22699,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Pictures"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Pictures"
 					If((validStateProp $Setting FRPicturesPath_Part State ) -and ($Setting.FRPicturesPath_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Pictures\Pictures path"
@@ -22766,7 +22773,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Saved Games"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Saved Games"
 					If((validStateProp $Setting FRSavedGames_Part State ) -and ($Setting.FRSavedGames_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Saved Games\Redirection settings for Saved Games"
@@ -22839,7 +22846,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Searches"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Searches"
 					If((validStateProp $Setting FRSearches_Part State ) -and ($Setting.FRSearches_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Searches\Redirection settings for Searches"
@@ -22912,7 +22919,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Start Menu"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Start Menu"
 					If((validStateProp $Setting FRStartMenu_Part State ) -and ($Setting.FRStartMenu_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Start Menu\Redirection settings for Start Menu"
@@ -22985,7 +22992,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Folder Redirection\Videos"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Folder Redirection\Videos"
 					If((validStateProp $Setting FRVideos_Part State ) -and ($Setting.FRVideos_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Folder Redirection\Videos\Redirection settings for Videos"
@@ -23059,7 +23066,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Log settings"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Log settings"
 					If((validStateProp $Setting LogLevel_ActiveDirectoryActions State ) -and ($Setting.LogLevel_ActiveDirectoryActions.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Log settings\Active Directory actions"
@@ -23378,7 +23385,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Profile handling"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Profile handling"
 					If((validStateProp $Setting ApplicationProfilesAutoMigration State ) -and ($Setting.ApplicationProfilesAutoMigration.State -ne "NotConfigured"))
 					{
 						#V1.44
@@ -23610,7 +23617,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Registry"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Registry"
 					If((validStateProp $Setting ExclusionList_Part State ) -and ($Setting.ExclusionList_Part.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Registry\Exclusion list"
@@ -23844,7 +23851,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Registry\Default Exclusions"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Registry\Default Exclusions"
 					If((validStateProp $Setting DefaultExclusionList State ) -and ($Setting.DefaultExclusionList.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Registry\Enable Default Exclusion list"
@@ -23934,7 +23941,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Streamed user profiles"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Streamed user profiles"
 					If((validStateProp $Setting PSAlwaysCache State ) -and ($Setting.PSAlwaysCache.State -ne "NotConfigured"))
 					{
 						$txt = "Profile Management\Streamed user profiles\Always cache"
@@ -24257,7 +24264,7 @@ Function ProcessCitrixPolicies
 							OutputPolicySetting $txt $Setting.PSPendingLockTimeout.Value 
 						}
 					}
-					Write-Verbose "$(Get-Date): `t`t`tProfile Management\Citrix Virtual Apps Optimization settings"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tProfile Management\Citrix Virtual Apps Optimization settings"
 					If((validStateProp $Setting XenAppOptimizationEnable State ) -and ($Setting.XenAppOptimizationEnable.State -ne "NotConfigured"))
 					{
 						#V1.44
@@ -24329,7 +24336,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tReceiver"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tReceiver"
 					If((validStateProp $Setting StorefrontAccountsList State ) -and ($Setting.StorefrontAccountsList.State -ne "NotConfigured"))
 					{
 						$txt = "Receiver\Storefront accounts list"
@@ -24474,7 +24481,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tVirtual Delivery Agent Settings"
 					If((validStateProp $Setting ControllerRegistrationIPv6Netmask State ) -and ($Setting.ControllerRegistrationIPv6Netmask.State -ne "NotConfigured"))
 					{
 						#AD specific setting
@@ -24590,7 +24597,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\CPU Usage Monitoring"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tVirtual Delivery Agent Settings\CPU Usage Monitoring"
 					If((validStateProp $Setting CPUUsageMonitoring_Enable State ) -and ($Setting.CPUUsageMonitoring_Enable.State -ne "NotConfigured"))
 					{
 						$txt = "Virtual Delivery Agent Settings\CPU Usage Monitoring\Enable Monitoring"
@@ -24658,7 +24665,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\HDX3DPro"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tVirtual Delivery Agent Settings\HDX3DPro"
 					If((validStateProp $Setting EnableLossless State ) -and ($Setting.EnableLossless.State -ne "NotConfigured"))
 					{
 						$txt = "Virtual Delivery Agent Settings\HDX3DPro\Enable lossless"
@@ -24710,7 +24717,7 @@ Function ProcessCitrixPolicies
 						$tmp = $Null
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\ICA Latency Monitoring"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tVirtual Delivery Agent Settings\ICA Latency Monitoring"
 					If((validStateProp $Setting ICALatencyMonitoring_Enable State ) -and ($Setting.ICALatencyMonitoring_Enable.State -ne "NotConfigured"))
 					{
 						$txt = "Virtual Delivery Agent Settings\ICA Latency Monitoring\Enable Monitoring"
@@ -24778,7 +24785,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\Monitoring"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tVirtual Delivery Agent Settings\Monitoring"
 					If((validStateProp $Setting SelectedFailureLevel State ) -and ($Setting.SelectedFailureLevel.State -ne "NotConfigured"))
 					{
 						$txt = "Virtual Delivery Agent Settings\Monitoring\Enable monitoring of application failures"
@@ -25028,7 +25035,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 					
-					Write-Verbose "$(Get-Date): `t`t`tVirtual Delivery Agent Settings\Profile Load Time Monitoring"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tVirtual Delivery Agent Settings\Profile Load Time Monitoring"
 					If((validStateProp $Setting ProfileLoadTimeMonitoring_Enable State ) -and ($Setting.ProfileLoadTimeMonitoring_Enable.State -ne "NotConfigured"))
 					{
 						$txt = "Virtual Delivery Agent Settings\Profile Load Time Monitoring\Enable Monitoring"
@@ -25074,7 +25081,7 @@ Function ProcessCitrixPolicies
 						}
 					}
 
-					Write-Verbose "$(Get-Date): `t`t`tVirtual IP"
+					Write-Verbose "$(Get-Date -Format G): `t`t`tVirtual IP"
 					If((validStateProp $Setting VirtualLoopbackSupport State ) -and ($Setting.VirtualLoopbackSupport.State -ne "NotConfigured"))
 					{
 						$txt = "Virtual IP\Virtual IP loopback support"
@@ -25249,8 +25256,8 @@ Function ProcessCitrixPolicies
 			}
 			$Filter = $Null
 			$Settings = $Null
-			Write-Verbose "$(Get-Date): `t`tFinished $($Policy.PolicyName)"
-			Write-Verbose "$(Get-Date): "
+			Write-Verbose "$(Get-Date -Format G): `t`tFinished $($Policy.PolicyName)"
+			Write-Verbose "$(Get-Date -Format G): "
 		}
 	}
 	ElseIf(!$?)
@@ -25263,9 +25270,9 @@ Function ProcessCitrixPolicies
 	}
 	
 	$Policies = $Null
-	Write-Verbose "$(Get-Date): `tRemoving $($xDriveName) PSDrive"
+	Write-Verbose "$(Get-Date -Format G): `tRemoving $($xDriveName) PSDrive"
 	Remove-PSDrive $xDriveName -EA 0 4>$Null
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputPolicySetting
@@ -25592,28 +25599,28 @@ Function GetCtxGPOsInAD
 {
 	#thanks to the Citrix Engineering Team for pointers and for Michael B. Smith for creating the function
 	#updated 07-Nov-13 to work in a Windows Workgroup environment
-	Write-Verbose "$(Get-Date): Testing for an Active Directory environment"
+	Write-Verbose "$(Get-Date -Format G): Testing for an Active Directory environment"
 	$root = [ADSI]"LDAP://RootDSE"
 	If([String]::IsNullOrEmpty($root.PSBase.Name))
 	{
-		Write-Verbose "$(Get-Date): `tNot in an Active Directory environment"
+		Write-Verbose "$(Get-Date -Format G): `tNot in an Active Directory environment"
 		$root = $Null
 		$xArray = @()
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): `tIn an Active Directory environment"
+		Write-Verbose "$(Get-Date -Format G): `tIn an Active Directory environment"
 		$domainNC = $root.defaultNamingContext.ToString()
 		$root = $Null
 		$xArray = @()
 
 		$domain = $domainNC.Replace( 'DC=', '' ).Replace( ',', '.' )
-		Write-Verbose "$(Get-Date): `tSearching \\$($domain)\sysvol\$($domain)\Policies"
+		Write-Verbose "$(Get-Date -Format G): `tSearching \\$($domain)\sysvol\$($domain)\Policies"
 		$sysvolFiles = @()
 		$sysvolFiles = Get-ChildItem -Recurse ( '\\' + $domain  + '\sysvol\' + $domain + '\Policies' ) -EA 0
 		If($sysvolFiles.Count -eq 0)
 		{
-			Write-Verbose "$(Get-Date): `tSearch timed out.  Retrying.  Searching \\ + $($domain)\sysvol\$($domain)\Policies a second time."
+			Write-Verbose "$(Get-Date -Format G): `tSearch timed out.  Retrying.  Searching \\ + $($domain)\sysvol\$($domain)\Policies a second time."
 			$sysvolFiles = Get-ChildItem -Recurse ( '\\' + $domain  + '\sysvol\' + $domain + '\Policies' ) -EA 0
 		}
 		ForEach( $file in $sysvolFiles )
@@ -25654,7 +25661,7 @@ Function ProcessConfigLogging
 		If(($Script:XDSite2.ProductCode -eq "XDT" -and ($Script:XDSite2.ProductEdition -eq "PLT" -or $Script:XDSite2.ProductEdition -eq "ENT")) -or `
 		($Script:XDSite2.ProductCode -eq "MPS" -and ($Script:XDSite2.ProductEdition -eq "PLT" -or $Script:XDSite2.ProductEdition -eq "ENT")))
 		{
-			Write-Verbose "$(Get-Date): Processing Configuration Logging"
+			Write-Verbose "$(Get-Date -Format G): Processing Configuration Logging"
 			$txt1 = "Logging"
 			If($MSword -or $PDF)
 			{
@@ -25673,7 +25680,7 @@ Function ProcessConfigLogging
 			}
 			
 			#preferences
-			Write-Verbose "$(Get-Date): `tConfiguration Logging Preferences"
+			Write-Verbose "$(Get-Date -Format G): `tConfiguration Logging Preferences"
 			$results = Get-XDLogging @XDParams1
 			
 			If($? -and $Null -ne $results)
@@ -25686,7 +25693,7 @@ Function ProcessConfigLogging
 				OutputWarning $txt
 			}
 			
-			Write-Verbose "$(Get-Date): `tConfiguration Logging Details"
+			Write-Verbose "$(Get-Date -Format G): `tConfiguration Logging Details"
 			$ConfigLogItems = Get-LogHighLevelOperation @XDParams2 -Filter {StartTime -ge $StartDate -and EndTime -le $EndDate} -SortBy "-StartTime"
 			If($? -and $Null -ne $ConfigLogItems)
 			{
@@ -25702,13 +25709,13 @@ Function ProcessConfigLogging
 				$txt = "Configuration Logging information could not be retrieved."
 				OutputWarning $txt
 			}
-			Write-Verbose "$(Get-Date): "
+			Write-Verbose "$(Get-Date -Format G): "
 		}
 		Else
 		{
 			$txt = "Not licensed for Configuration Logging"
 			OutputWarning $txt
-			Write-Verbose "$(Get-Date): "
+			Write-Verbose "$(Get-Date -Format G): "
 		}
 	}
 }
@@ -25719,7 +25726,7 @@ Function OutputConfigLogPreferences
 
 	Param([object] $Preferences)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Configuration Logging Preferences"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Configuration Logging Preferences"
 	
 	$LogSQLServerPrincipalName = ""
 	$LogSQLServerMirrorName = ""
@@ -25865,7 +25872,7 @@ Function OutputConfigLog
 {
 	Param([object] $ConfigLogItems)
 	
-	Write-Verbose "$(Get-Date): `tOutput Configuration Logging"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Configuration Logging"
 	If($MSWord -or $PDF)
 	{
 		[System.Collections.Hashtable[]] $ItemsWordTable = @();
@@ -25963,16 +25970,16 @@ Function OutputConfigLog
 #region site configuration functions
 Function ProcessConfiguration
 {
-	Write-Verbose "$(Get-Date): Process Configuration Settings"
+	Write-Verbose "$(Get-Date -Format G): Process Configuration Settings"
 	OutputSiteSettings
 	OutputCEIPSetting
 	OutputDatastores
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputSiteSettings
 {
-	Write-Verbose "$(Get-Date): `tSee if StoreFront is installed on the Controller(s)"
+	Write-Verbose "$(Get-Date -Format G): `tSee if StoreFront is installed on the Controller(s)"
 	$DefaultStoreFrontAddress = ""
 	If(Get-SFIsStoreFrontInstalled @XDParams1)
 	{
@@ -25987,7 +25994,7 @@ Function OutputSiteSettings
 		}	
 	}
 
-	Write-Verbose "$(Get-Date): `tOutput Site Settings"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Site Settings"
 	If($MSWord -or $PDF)
 	{
 		$Selection.InsertNewPage()
@@ -26038,7 +26045,7 @@ Function OutputCEIPSetting
 {
 	If($Script:CanDoAnalytics)
 	{
-		Write-Verbose "$(Get-Date): `tProcessing Customer Experience Improvement Program"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing Customer Experience Improvement Program"
 		$Results = Get-AnalyticsSite @XDParams1
 		If($? -and ($Null -ne $Results))
 		{
@@ -26184,8 +26191,8 @@ Function OutputDatastores
 	#25-Jun-2017 add checking if the SQL Server assembly loaded before calculating the database size
 	
 	#V1.42 added get IP address for each SQL Server name
-	Write-Verbose "$(Get-Date): `tRetrieving database connection data"
-	Write-Verbose "$(Get-Date): `t`tConfiguration database"
+	Write-Verbose "$(Get-Date -Format G): `tRetrieving database connection data"
+	Write-Verbose "$(Get-Date -Format G): `t`tConfiguration database"
 	[string]$ConfigSQLServerPrincipalName = ""
 	[string]$ConfigSQLServerMirrorName = "Not Configured"
 	[string]$ConfigDatabaseName = ""
@@ -26194,6 +26201,7 @@ Function OutputDatastores
 	[string]$ConfigDBSQLVersion = "Unable to determine"
 	[string]$ConfigSQLServerPrincipalNameIPAddress = ""
 	[string]$ConfigSQLServerMirrorNameIPAddress = ""
+	$SQLServerNames = @()
 	
 	$ConfigDBs = Get-ConfigDBConnection @XDParams1
 
@@ -26217,10 +26225,14 @@ Function OutputDatastores
 		If($ConfigSQLServerPrincipalName.Contains("\"))
 		{
 			$ConfigSQLServerPrincipalNameIPAddress = Get-IPAddress $ConfigSQLServerPrincipalName.Substring(0,$ConfigSQLServerPrincipalName.IndexOf("\"))
+			#add in V1.47 get hardware info for the sql server(s)
+			$SQLServerNames += $ConfigSQLServerPrincipalName.Substring(0,$ConfigSQLServerPrincipalName.IndexOf("\"))
 		}
 		Else
 		{
 			$ConfigSQLServerPrincipalNameIPAddress = Get-IPAddress $ConfigSQLServerPrincipalName
+			#add in V1.47 get hardware info for the sql server(s)
+			$SQLServerNames += $ConfigSQLServerPrincipalName
 		}
 
 		If($ConfigSQLServerMirrorName -ne "Not Configured")
@@ -26228,17 +26240,21 @@ Function OutputDatastores
 			If($ConfigSQLServerMirrorName.Contains("\"))
 			{
 				$ConfigSQLServerMirrorNameIPAddress = Get-IPAddress $ConfigSQLServerMirrorName.Substring(0,$ConfigSQLServerMirrorName.IndexOf("\"))
+				#add in V1.47 get hardware info for the sql server(s)
+				$SQLServerNames += $ConfigSQLServerMirrorName.Substring(0,$ConfigSQLServerMirrorName.IndexOf("\"))
 			}
 			Else
 			{
 				$ConfigSQLServerMirrorNameIPAddress = Get-IPAddress $ConfigSQLServerMirrorName
+				#add in V1.47 get hardware info for the sql server(s)
+				$SQLServerNames += $ConfigSQLServerMirrorName
 			}
 		}
 		Else
 		{
 			$ConfigSQLServerMirrorNameIPAddress = "-"
 		}
-
+		
 		If($Script:SQLServerLoaded)
 		{
 			$SQLsrv = new-Object Microsoft.SqlServer.Management.Smo.Server("$($ConfigSQLServerPrincipalName)")
@@ -26263,7 +26279,7 @@ Function OutputDatastores
 			$ConfigDBParent 									= $Configdb.Parent
 			$ConfigDBCollation 									= $Configdb.Collation
 			$ConfigDBSQLVersion 								= GetSQLVersion $SQLsrv
-			$ConfigDBCompatibilityLevel 						= GetDBCompatibilityLevel $Configdb.CompatibilityLevel
+			$ConfigDBCompatibilityLevel 						= GetDBCompatibilityLevel $Configdb.CompatibilityLevel $SQLsrv
 			$ConfigDBCreateDate 								= $Configdb.CreateDate.ToString()
 
 			If($Configdb.IsReadCommittedSnapshotOn)
@@ -26296,10 +26312,14 @@ Function OutputDatastores
 				If($Configdb.MirroringPartner.Contains("\"))
 				{
 					$ConfigDBMirroringPartnerIPAddress = Get-IPAddress $Configdb.MirroringPartner.Substring(0,$Configdb.MirroringPartner.IndexOf("\"))
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Configdb.MirroringPartner.Substring(0,$Configdb.MirroringPartner.IndexOf("\"))
 				}
 				Else
 				{
 					$ConfigDBMirroringPartnerIPAddress = Get-IPAddress $Configdb.MirroringPartner
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Configdb.MirroringPartner
 				}
 				$ConfigDBMirroringPartnerInstance	= $Configdb.MirroringPartnerInstance
 				$ConfigDBMirroringSafetyLevel		= $Configdb.MirroringSafetyLevel
@@ -26309,10 +26329,14 @@ Function OutputDatastores
 				If($Configdb.MirroringPartner.Contains("\"))
 				{
 					$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness.Substring(0,$Configdb.MirroringWitness.IndexOf("\"))
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Configdb.MirroringWitness.Substring(0,$Configdb.MirroringWitness.IndexOf("\"))
 				}
 				Else
 				{
 					$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Configdb.MirroringWitness
 				}
 				$ConfigDBMirroringWitnessStatus		= $Configdb.MirroringWitnessStatus
 			}
@@ -26356,15 +26380,16 @@ Function OutputDatastores
 		Write-Warning "Unable to retrieve Configuration Database settings"
 	}
 
-	Write-Verbose "$(Get-Date): `t`tConfiguration Logging database"
-	[string]$LogSQLServerPrincipalName = ""
-	[string]$LogSQLServerMirrorName = "Not Configured"
-	[string]$LogDatabaseName = ""
-	[string]$LogDBSize = "Unable to determine"
-	[string]$LogDBReadCommittedSnapshot = "Unable to determine"
-	[string]$LogDBSQLVersion = "Unable to determine"
+	Write-Verbose "$(Get-Date -Format G): `t`tConfiguration Logging database"
+	[string]$LogSQLServerPrincipalName          = ""
+	[string]$LogSQLServerMirrorName             = "Not Configured"
+	[string]$LogDatabaseName                    = ""
+	[string]$LogDBSize                          = "Unable to determine"
+	[string]$LogDBReadCommittedSnapshot         = "Unable to determine"
+	[string]$LogDBSQLVersion                    = "Unable to determine"
 	[string]$LogSQLServerPrincipalNameIPAddress = ""
-	[string]$LogSQLServerMirrorNameIPAddress = ""
+	[string]$LogSQLServerMirrorNameIPAddress    = ""
+
 	$LogDBs = Get-LogDataStore @XDParams1
 
 	If($? -and ($Null -ne $LogDBs))
@@ -26393,10 +26418,14 @@ Function OutputDatastores
 		If($LogSQLServerPrincipalName.Contains("\"))
 		{
 			$LogSQLServerPrincipalNameIPAddress = Get-IPAddress $LogSQLServerPrincipalName.Substring(0,$LogSQLServerPrincipalName.IndexOf("\"))
+			#add in V1.47 get hardware info for the sql server(s)
+			$SQLServerNames += $LogSQLServerPrincipalName.Substring(0,$LogSQLServerPrincipalName.IndexOf("\"))
 		}
 		Else
 		{
 			$LogSQLServerPrincipalNameIPAddress = Get-IPAddress $LogSQLServerPrincipalName
+			#add in V1.47 get hardware info for the sql server(s)
+			$SQLServerNames += $LogSQLServerPrincipalName
 		}
 
 		If($LogSQLServerMirrorName -ne "Not Configured")
@@ -26404,10 +26433,14 @@ Function OutputDatastores
 			If($LogSQLServerMirrorName.Contains("\"))
 			{
 				$LogSQLServerMirrorNameIPAddress = Get-IPAddress $LogSQLServerMirrorName.Substring(0,$LogSQLServerMirrorName.IndexOf("\"))
+				#add in V1.47 get hardware info for the sql server(s)
+				$SQLServerNames += $LogSQLServerMirrorName.Substring(0,$LogSQLServerMirrorName.IndexOf("\"))
 			}
 			Else
 			{
 				$LogSQLServerMirrorNameIPAddress = Get-IPAddress $LogSQLServerMirrorName
+				#add in V1.47 get hardware info for the sql server(s)
+				$SQLServerNames += $LogSQLServerMirrorName
 			}
 		}
 		Else
@@ -26436,11 +26469,11 @@ Function OutputDatastores
 				}
 			}
 
-			$LogDBParent 									= $LogDB.Parent
-			$LogDBCollation 								= $LogDB.Collation
-			$LogDBSQLVersion 								= GetSQLVersion $SQLsrv
-			$LogDBCompatibilityLevel 						= GetDBCompatibilityLevel $LogDB.CompatibilityLevel
-			$LogDBCreateDate 								= $LogDB.CreateDate.ToString()
+			$LogDBParent			 = $LogDB.Parent
+			$LogDBCollation			 = $LogDB.Collation
+			$LogDBSQLVersion		 = GetSQLVersion $SQLsrv
+			$LogDBCompatibilityLevel = GetDBCompatibilityLevel $LogDB.CompatibilityLevel $SQLsrv
+			$LogDBCreateDate		 = $LogDB.CreateDate.ToString()
 
 			If($LogDB.IsReadCommittedSnapshotOn)
 			{
@@ -26472,10 +26505,14 @@ Function OutputDatastores
 				If($Logdb.MirroringPartner.Contains("\"))
 				{
 					$LogDBMirroringPartnerIPAddress = Get-IPAddress $Logdb.MirroringPartner.Substring(0,$Logdb.MirroringPartner.IndexOf("\"))
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Logdb.MirroringPartner.Substring(0,$Logdb.MirroringPartner.IndexOf("\"))
 				}
 				Else
 				{
 					$LogDBMirroringPartnerIPAddress = Get-IPAddress $Logdb.MirroringPartner
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Logdb.MirroringPartner
 				}
 				$LogDBMirroringPartnerInstance	= $LogDB.MirroringPartnerInstance
 				$LogDBMirroringSafetyLevel		= $LogDB.MirroringSafetyLevel
@@ -26484,10 +26521,14 @@ Function OutputDatastores
 				If($Logdb.MirroringPartner.Contains("\"))
 				{
 					$LogDBMirroringWitnessIPAddress = Get-IPAddress $Logdb.MirroringWitness.Substring(0,$Logdb.MirroringWitness.IndexOf("\"))
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Logdb.MirroringWitness.Substring(0,$Logdb.MirroringWitness.IndexOf("\"))
 				}
 				Else
 				{
 					$LogDBMirroringWitnessIPAddress = Get-IPAddress $Logdb.MirroringWitness
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Logdb.MirroringWitness
 				}
 				$LogDBMirroringWitnessStatus	= $LogDB.MirroringWitnessStatus
 			}
@@ -26531,18 +26572,18 @@ Function OutputDatastores
 		Write-Warning "Unable to retrieve Configuration Logging Database settings"
 	}
 
-	Write-Verbose "$(Get-Date): `t`tMonitoring database"
-	[string]$MonitorSQLServerPrincipalName = ""
-	[string]$MonitorSQLServerMirrorName = "Not Configured"
-	[string]$MonitorDatabaseName = ""
-	[string]$MonitorDBSize = "Unable to determine"
-	[string]$MonitorDBReadCommittedSnapshot = "Unable to determine"
-	[string]$MonitorDBSQLVersion = "Unable to determine"
-	[string]$MonitorCollectHotfix = "Disabled"
-	[string]$MonitorDataCollection = "Disabled"
-	[string]$MonitorDetailedSQL = "Disabled"
+	Write-Verbose "$(Get-Date -Format G): `t`tMonitoring database"
+	[string]$MonitorSQLServerPrincipalName          = ""
+	[string]$MonitorSQLServerMirrorName             = "Not Configured"
+	[string]$MonitorDatabaseName                    = ""
+	[string]$MonitorDBSize                          = "Unable to determine"
+	[string]$MonitorDBReadCommittedSnapshot         = "Unable to determine"
+	[string]$MonitorDBSQLVersion                    = "Unable to determine"
+	[string]$MonitorCollectHotfix                   = "Disabled"
+	[string]$MonitorDataCollection                  = "Disabled"
+	[string]$MonitorDetailedSQL                     = "Disabled"
 	[string]$MonitorSQLServerPrincipalNameIPAddress = ""
-	[string]$MonitorSQLServerMirrorNameIPAddress = ""
+	[string]$MonitorSQLServerMirrorNameIPAddress    = ""
 	
 	$MonitorDBs = Get-MonitorDataStore @XDParams1
 
@@ -26572,10 +26613,14 @@ Function OutputDatastores
 		If($MonitorSQLServerPrincipalName.Contains("\"))
 		{
 			$MonitorSQLServerPrincipalNameIPAddress = Get-IPAddress $MonitorSQLServerPrincipalName.Substring(0,$MonitorSQLServerPrincipalName.IndexOf("\"))
+			#add in V1.47 get hardware info for the sql server(s)
+			$SQLServerNames += $MonitorSQLServerPrincipalName.Substring(0,$MonitorSQLServerPrincipalName.IndexOf("\"))
 		}
 		Else
 		{
 			$MonitorSQLServerPrincipalNameIPAddress = Get-IPAddress $MonitorSQLServerPrincipalName
+			#add in V1.47 get hardware info for the sql server(s)
+			$SQLServerNames += $MonitorSQLServerPrincipalName
 		}
 
 		If($MonitorSQLServerMirrorName -ne "Not Configured")
@@ -26583,10 +26628,14 @@ Function OutputDatastores
 			If($MonitorSQLServerMirrorName.Contains("\"))
 			{
 				$MonitorSQLServerMirrorNameIPAddress = Get-IPAddress $MonitorSQLServerMirrorName.Substring(0,$MonitorSQLServerMirrorName.IndexOf("\"))
+				#add in V1.47 get hardware info for the sql server(s)
+				$SQLServerNames += $MonitorSQLServerMirrorName.Substring(0,$MonitorSQLServerMirrorName.IndexOf("\"))
 			}
 			Else
 			{
 				$MonitorSQLServerMirrorNameIPAddress = Get-IPAddress $MonitorSQLServerMirrorName
+				#add in V1.47 get hardware info for the sql server(s)
+				$SQLServerNames += $MonitorSQLServerMirrorName
 			}
 		}
 		Else
@@ -26618,7 +26667,7 @@ Function OutputDatastores
 			$MonitorDBParent 				= $MonitorDB.Parent
 			$MonitorDBCollation 			= $MonitorDB.Collation
 			$MonitorDBSQLVersion 			= GetSQLVersion $SQLsrv
-			$MonitorDBCompatibilityLevel	= GetDBCompatibilityLevel $MonitorDB.CompatibilityLevel
+			$MonitorDBCompatibilityLevel	= GetDBCompatibilityLevel $MonitorDB.CompatibilityLevel $SQLsrv
 			$MonitorDBCreateDate 			= $MonitorDB.CreateDate.ToString()
 
 			If($MonitorDB.IsReadCommittedSnapshotOn)
@@ -26651,10 +26700,14 @@ Function OutputDatastores
 				If($Monitordb.MirroringPartner.Contains("\"))
 				{
 					$MonitorDBMirroringPartnerIPAddress = Get-IPAddress $Monitordb.MirroringPartner.Substring(0,$Monitordb.MirroringPartner.IndexOf("\"))
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Monitordb.MirroringPartner.Substring(0,$Monitordb.MirroringPartner.IndexOf("\"))
 				}
 				Else
 				{
 					$MonitorDBMirroringPartnerIPAddress = Get-IPAddress $Monitordb.MirroringPartner
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $Monitordb.MirroringPartner
 				}
 				$MonitorDBMirroringPartnerInstance	= $MonitorDB.MirroringPartnerInstance
 				$MonitorDBMirroringSafetyLevel		= $MonitorDB.MirroringSafetyLevel
@@ -26662,11 +26715,15 @@ Function OutputDatastores
 				$MonitorDBMirroringWitness			= $MonitorDB.MirroringWitness
 				If($Configdb.MirroringPartner.Contains("\"))
 				{
-					$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness.Substring(0,$Configdb.MirroringWitness.IndexOf("\"))
+					$MonitorDBMirroringWitnessIPAddress = Get-IPAddress $MonitorDB.MirroringWitness.Substring(0,$MonitorDB.MirroringWitness.IndexOf("\"))
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $MonitorDB.MirroringWitness.Substring(0,$MonitorDB.MirroringWitness.IndexOf("\"))
 				}
 				Else
 				{
-					$ConfigDBMirroringWitnessIPAddress = Get-IPAddress $Configdb.MirroringWitness
+					$MonitorDBMirroringWitnessIPAddress = Get-IPAddress $MonitorDB.MirroringWitness
+					#add in V1.47 get hardware info for the sql server(s)
+					$SQLServerNames += $MonitorDB.MirroringWitness
 				}
 				$MonitorDBMirroringWitnessStatus	= $MonitorDB.MirroringWitnessStatus
 			}
@@ -26743,7 +26800,310 @@ Function OutputDatastores
 		Write-Warning "Unable to retrieve Monitoring Database settings"
 	}
 
-	Write-Verbose "$(Get-Date): `tOutput Datastores"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Datastores"
+	If($Script:SQLServerLoaded)
+	{
+		If([String]::IsNullOrEmpty( $ConfigDatabaseName))
+		{
+			$ConfigDatabaseName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBAvailabilityDatabaseSynchronizationState))
+		{
+			$ConfigDBAvailabilityDatabaseSynchronizationState = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBAvailabilityGroupName))
+		{
+			$ConfigDBAvailabilityGroupName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBCollation))
+		{
+			$ConfigDBCollation = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBCompatibilityLevel))
+		{
+			$ConfigDBCompatibilityLevel = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBCreateDate))
+		{
+			$ConfigDBCreateDate = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBSize))
+		{
+			$ConfigDBSize = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBLastBackupDate))
+		{
+			$ConfigDBLastBackupDate = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBLastLogBackupDate))
+		{
+			$ConfigDBLastLogBackupDate = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigSQLServerMirrorName))
+		{
+			$ConfigSQLServerMirrorName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigSQLServerMirrorNameIPAddress))
+		{
+			$ConfigSQLServerMirrorNameIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBMirroringPartner))
+		{
+			$ConfigDBMirroringPartner = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBMirroringPartnerIPAddress))
+		{
+			$ConfigDBMirroringPartnerIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBMirroringPartnerInstance))
+		{
+			$ConfigDBMirroringPartnerInstance = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBMirroringSafetyLevel))
+		{
+			$ConfigDBMirroringSafetyLevel = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBMirroringStatus))
+		{
+			$ConfigDBMirroringStatus = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBMirroringWitness))
+		{
+			$ConfigDBMirroringWitness = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBMirroringWitnessIPAddress))
+		{
+			$ConfigDBMirroringWitnessIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBMirroringWitnessStatus))
+		{
+			$ConfigDBMirroringWitnessStatus = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBParent))
+		{
+			$ConfigDBParent = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBReadCommittedSnapshot))
+		{
+			$ConfigDBReadCommittedSnapshot = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBRecoveryModel))
+		{
+			$ConfigDBRecoveryModel = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigSQLServerPrincipalName))
+		{
+			$ConfigSQLServerPrincipalName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigSQLServerPrincipalNameIPAddress))
+		{
+			$ConfigSQLServerPrincipalNameIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $ConfigDBSQLVersion))
+		{
+			$ConfigDBSQLVersion = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDatabaseName))
+		{
+			$LogDatabaseName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBAvailabilityDatabaseSynchronizationState))
+		{
+			$LogDBAvailabilityDatabaseSynchronizationState = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBAvailabilityGroupName))
+		{
+			$LogDBAvailabilityGroupName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBCollation))
+		{
+			$LogDBCollation = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBCompatibilityLevel))
+		{
+			$LogDBCompatibilityLevel = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBCreateDate))
+		{
+			$LogDBCreateDate = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBSize))
+		{
+			$LogDBSize = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBLastBackupDate))
+		{
+			$LogDBLastBackupDate = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBLastLogBackupDate))
+		{
+			$LogDBLastLogBackupDate = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogSQLServerMirrorName))
+		{
+			$LogSQLServerMirrorName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogSQLServerMirrorNameIPAddress))
+		{
+			$LogSQLServerMirrorNameIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBMirroringPartner))
+		{
+			$LogDBMirroringPartner = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBMirroringPartnerIPAddress))
+		{
+			$LogDBMirroringPartnerIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBMirroringPartnerInstance))
+		{
+			$LogDBMirroringPartnerInstance = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBMirroringSafetyLevel))
+		{
+			$LogDBMirroringSafetyLevel = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBMirroringStatus))
+		{
+			$LogDBMirroringStatus = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBMirroringWitness))
+		{
+			$LogDBMirroringWitness = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBMirroringWitnessIPAddress))
+		{
+			$LogDBMirroringWitnessIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBMirroringWitnessStatus))
+		{
+			$LogDBMirroringWitnessStatus = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBParent))
+		{
+			$LogDBParent = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBReadCommittedSnapshot))
+		{
+			$LogDBReadCommittedSnapshot = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBRecoveryModel))
+		{
+			$LogDBRecoveryModel = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogSQLServerPrincipalName))
+		{
+			$LogSQLServerPrincipalName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogSQLServerPrincipalNameIPAddress))
+		{
+			$LogSQLServerPrincipalNameIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $LogDBSQLVersion))
+		{
+			$LogDBSQLVersion = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDatabaseName))
+		{
+			$MonitorDatabaseName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBAvailabilityDatabaseSynchronizationState))
+		{
+			$MonitorDBAvailabilityDatabaseSynchronizationState = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBAvailabilityGroupName))
+		{
+			$MonitorDBAvailabilityGroupName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBCollation))
+		{
+			$MonitorDBCollation = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBCompatibilityLevel))
+		{
+			$MonitorDBCompatibilityLevel = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBCreateDate))
+		{
+			$MonitorDBCreateDate = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBSize))
+		{
+			$MonitorDBSize = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBLastBackupDate))
+		{
+			$MonitorDBLastBackupDate = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBLastLogBackupDate))
+		{
+			$MonitorDBLastLogBackupDate = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorSQLServerMirrorName))
+		{
+			$MonitorSQLServerMirrorName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorSQLServerMirrorNameIPAddress))
+		{
+			$MonitorSQLServerMirrorNameIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBMirroringPartner))
+		{
+			$MonitorDBMirroringPartner = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBMirroringPartnerIPAddress))
+		{
+			$MonitorDBMirroringPartnerIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBMirroringPartnerInstance))
+		{
+			$MonitorDBMirroringPartnerInstance = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBMirroringSafetyLevel))
+		{
+			$MonitorDBMirroringSafetyLevel = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBMirroringStatus))
+		{
+			$MonitorDBMirroringStatus = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBMirroringWitness))
+		{
+			$MonitorDBMirroringWitness = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBMirroringWitnessIPAddress))
+		{
+			$MonitorDBMirroringWitnessIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBMirroringWitnessStatus))
+		{
+			$MonitorDBMirroringWitnessStatus = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBParent))
+		{
+			$MonitorDBParent = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBReadCommittedSnapshot))
+		{
+			$MonitorDBReadCommittedSnapshot = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBRecoveryModel))
+		{
+			$MonitorDBRecoveryModel = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorSQLServerPrincipalName))
+		{
+			$MonitorSQLServerPrincipalName = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorSQLServerPrincipalNameIPAddress))
+		{
+			$MonitorSQLServerPrincipalNameIPAddress = "Unable to determine"
+		}
+		If([String]::IsNullOrEmpty( $MonitorDBSQLVersion))
+		{
+			$MonitorDBSQLVersion = "Unable to determine"
+		}
+		
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 2 0 "Datastores"
@@ -27394,14 +27754,47 @@ Function OutputDatastores
 		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "250"
 		WriteHTMLLine 0 0 " "
 	}
+		
+		If($Hardware)
+		{
+			$SQLServerNames = $SQLServerNames | Sort-Object -Unique
+			
+			ForEach($SQLServerName in $SQLServerNames)
+			{
+				If($MSWord -or $PDF)
+				{
+					$Script:Selection.InsertNewPage()
+				}
+				GetComputerWMIInfo $SQLServerName
+			}
+		}
+	}
+	Else
+	{
+		If($MSWord -or $PDF)
+		{
+			WriteWordLine 2 0 "Datastores"
+			WriteWordLine 0 0 "There is no Datastore information becaue the SQL Server Assembly did not load"
+		}
+		If($Text)
+		{
+			Line 0 "Datastores"
+			Line 0 "There is no Datastore information becaue the SQL Server Assembly did not load"
+		}
+		If($HTML)
+		{
+			WriteHTMLLine 2 0 "Datastores"
+			WriteHTMLLine 0 0 "There is no Datastore information becaue the SQL Server Assembly did not load"
+		}
+	}
 }
 #endregion
 
 #region Administrator, Scope and Roles functions
 Function ProcessAdministrators
 {
-	Write-Verbose "$(Get-Date): Processing Administrators"
-	Write-Verbose "$(Get-Date): `tRetrieving Administrator data"
+	Write-Verbose "$(Get-Date -Format G): Processing Administrators"
+	Write-Verbose "$(Get-Date -Format G): `tRetrieving Administrator data"
 	
 	$Script:TotalDeliveryGroupAdmins = 0
 	$Script:TotalFullAdmins = 0
@@ -27427,14 +27820,14 @@ Function ProcessAdministrators
 		$txt = "Unable to retrieve Administrators"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputAdministrators
 {
 	Param([object] $Admins)
 	
-	Write-Verbose "$(Get-Date): `tOutput Administrator data"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Administrator data"
 	
 	ForEach($Admin in $Admins)
 	{
@@ -27539,7 +27932,7 @@ Function OutputAdministrators
 
 Function ProcessScopes
 {
-	Write-Verbose "$(Get-Date): Processing Administrator Scopes"
+	Write-Verbose "$(Get-Date -Format G): Processing Administrator Scopes"
 	$Scopes = Get-AdminScope @XDParams2 -SortBy Name
 	
 	If($? -and ($Null -ne $Scopes))
@@ -27561,14 +27954,14 @@ Function ProcessScopes
 		$txt = "Unable to retrieve Administrator Scopes"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputScopes
 {
 	Param([object] $Scopes)
 	
-	Write-Verbose "$(Get-Date): `tOutput Scopes"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Scopes"
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 2 0 "Administrative Scopes"
@@ -27627,7 +28020,7 @@ Function OutputScopeObjects
 {
 	Param([object] $Scopes)
 	
-	Write-Verbose "$(Get-Date): `t`tOutput Scope Objects"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Scope Objects"
 
 	If($MSWord -or $PDF)
 	{
@@ -27976,7 +28369,7 @@ Function GetScopeHyp
 Function OutputScopeAdministrators 
 {
 	Param([object] $Scopes)
-	Write-Verbose "$(Get-Date): `t`tOutput Scope Administrators"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Scope Administrators"
 	
 	If($MSWord -or $PDF)
 	{
@@ -28147,7 +28540,7 @@ Function OutputScopeAdministrators
 
 Function ProcessRoles
 {
-	Write-Verbose "$(Get-Date): Processing Administrator Roles"
+	Write-Verbose "$(Get-Date -Format G): Processing Administrator Roles"
 	$Roles = Get-AdminRole @XDParams2 -SortBy Name
 
 	If($? -and ($Null -ne $Roles))
@@ -28169,14 +28562,14 @@ Function ProcessRoles
 		$txt = "Unable to retrieve Administrator Roles"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputRoles
 {
 	Param([object] $Roles)
 	
-	Write-Verbose "$(Get-Date): `tOutput Roles"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Roles"
 	If($MSWord -or $PDF)
 	{
 		If($Administrators)
@@ -28272,7 +28665,7 @@ Function OutputRoles
 Function OutputRoleDefinitions
 {
 	Param([object] $Roles)
-	Write-Verbose "$(Get-Date): `t`tOutput Role Definitions"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Role Definitions"
 	
 	If($MSWord -or $PDF)
 	{
@@ -28548,7 +28941,7 @@ Function GetRolePermissions
 Function OutputRoleAdministrators 
 {
 	Param([object] $Roles)
-	Write-Verbose "$(Get-Date): `t`tOutput Role Administrators"
+	Write-Verbose "$(Get-Date -Format G): `t`tOutput Role Administrators"
 	
 	If($MSWord -or $PDF)
 	{
@@ -28721,8 +29114,8 @@ Function OutputRoleAdministrators
 #region Controllers functions
 Function ProcessControllers
 {
-	Write-Verbose "$(Get-Date): Processing Controllers"
-	Write-Verbose "$(Get-Date): `tRetrieving Controller data"
+	Write-Verbose "$(Get-Date -Format G): Processing Controllers"
+	Write-Verbose "$(Get-Date -Format G): `tRetrieving Controller data"
 	
 	$Script:TotalControllers = 0
 	
@@ -28742,14 +29135,14 @@ Function ProcessControllers
 		$txt = "Unable to retrieve Controllers"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputControllers
 {
 	Param([object]$Controllers)
 	
-	Write-Verbose "$(Get-Date): `tOutput Controllers"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Controllers"
 	If($MSWord -or $PDF)
 	{
 		$Selection.InsertNewPage()
@@ -28843,7 +29236,7 @@ Function ProcessHosting
 {
 	#original work on the Hosting was done by Kenny Baldwin
 	#V1.44 updated to match the V2 script
-	Write-Verbose "$(Get-Date): Processing Hosting"
+	Write-Verbose "$(Get-Date -Format G): Processing Hosting"
 	
 	$Script:TotalHostingConnections = 0
 
@@ -28868,7 +29261,7 @@ Function ProcessHosting
 	$vmnetwork = @()
 	$IntelliCache = New-Object System.Collections.ArrayList
 
-	Write-Verbose "$(Get-Date): `tProcessing Hosting Units"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Hosting Units"
 	$HostingUnits = Get-ChildItem @XDParams1 -path 'xdhyp:\hostingunits' 4>$Null
 	If($? -and $Null -ne $HostingUnits)
 	{
@@ -28910,7 +29303,7 @@ Function ProcessHosting
 		OutputWarning $txt
 	}
 
-	Write-Verbose "$(Get-Date): `tProcessing Hypervisors"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing Hypervisors"
 	$Hypervisors = Get-BrokerHypervisorConnection @XDParams2
 	If($? -and $Null -ne $Hypervisors)
 	{
@@ -28992,7 +29385,7 @@ Function ProcessHosting
 			$xState = ""
 			$xZoneName = ""
 			$xPowerActions = @()
-			Write-Verbose "$(Get-Date): `tProcessing Hosting Connections"
+			Write-Verbose "$(Get-Date -Format G): `tProcessing Hosting Connections"
 			$Connections = Get-ChildItem @XDParams1 -path 'xdhyp:\connections' 4>$Null
 			
 			If($? -and $Null -ne $Connections)
@@ -29046,7 +29439,7 @@ Function ProcessHosting
 		$txt = "Unable to retrieve Hypervisors"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date):"
+	Write-Verbose "$(Get-Date -Format G):"
 }
 
 Function OutputHosting
@@ -29171,7 +29564,7 @@ Function OutputHosting
 		$xxMaintMode = "Off"
 	}
 	
-	Write-Verbose "$(Get-Date): `t`t`tOutput $($Hypervisor.Name)"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tOutput $($Hypervisor.Name)"
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 3 0 $Hypervisor.Name
@@ -29521,7 +29914,7 @@ Function OutputHosting
 	
 	If($Hosting)
 	{	
-		Write-Verbose "$(Get-Date): `tProcessing Host Administrators"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing Host Administrators"
 		$Admins = GetAdmins "Host" $Hypervisor.Name
 		
 		If($? -and ($Null -ne $Admins))
@@ -29539,7 +29932,7 @@ Function OutputHosting
 			OutputWarning $txt
 		}
 
-		Write-Verbose "$(Get-Date): `tProcessing Desktop OS Data"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing Desktop OS Data"
 		$DesktopOSMachines = @(Get-BrokerMachine @XDParams2 -hypervisorconnectionname $Hypervisor.Name -sessionsupport "SingleSession")
 
 		If($? -and ($Null -ne $DesktopOSMachines))
@@ -29577,7 +29970,7 @@ Function OutputHosting
 			OutputWarning $txt
 		}
 
-		Write-Verbose "$(Get-Date): `tProcessing Server OS Data"
+		Write-Verbose "$(Get-Date -Format G): `tProcessing Server OS Data"
 		$ServerOSMachines = @(Get-BrokerMachine @XDParams2 -hypervisorconnectionname $Hypervisor.Name -sessionsupport "MultiSession")
 		
 		If($? -and ($Null -ne $ServerOSMachines))
@@ -29618,7 +30011,7 @@ Function OutputHosting
 
 		If($NoSessions -eq $False) #V2.27
 		{
-			Write-Verbose "$(Get-Date): `tProcessing Sessions Data"
+			Write-Verbose "$(Get-Date -Format G): `tProcessing Sessions Data"
 			$Sessions = @(Get-BrokerSession @XDParams2 -hypervisorconnectionname $Hypervisor.Name -SortBy UserName)
 			If($? -and ($Null -ne $Sessions))
 			{
@@ -29664,7 +30057,7 @@ Function OutputDesktopOSMachine
 	$xMaintMode = ""
 	$xUserChanges = ""
 	
-	Write-Verbose "$(Get-Date): `t`t`tOutput desktop $($Desktop.DNSName)"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tOutput desktop $($Desktop.DNSName)"
 	If($MSWord -or $PDF)
 	{
 		If(![String]::IsNullOrEmpty($Desktop.AssociatedUserNames))
@@ -29812,7 +30205,7 @@ Function OutputServerOSMachine
 {
 	Param([object]$Server)
 	
-	Write-Verbose "$(Get-Date): `t`t`tOutput server $($Server.DNSName)"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tOutput server $($Server.DNSName)"
 	$xName = ""
 	$xMaintMode = ""
 	$xUserChanges = ""
@@ -29967,7 +30360,7 @@ Function OutputHostingSessions
 	
 	ForEach($Session in $Sessions)
 	{
-		Write-Verbose "$(Get-Date): `t`t`tOutput session $($Session.UserName)"
+		Write-Verbose "$(Get-Date -Format G): `t`t`tOutput session $($Session.UserName)"
 		
 		If($Session.SessionSupport -eq "SingleSession")
 		{
@@ -30042,13 +30435,13 @@ Function OutputHostingSessions
 #region Licensing functions
 Function ProcessLicensing
 {
-	Write-Verbose "$(Get-Date): Processing Licensing"
+	Write-Verbose "$(Get-Date -Format G): Processing Licensing"
 	
 	$Script:Licenses = @()
 	OutputLicensingOverview
 	
 	#get product license info
-	Write-Verbose "$(Get-Date): `tRetrieving Licensing data"
+	Write-Verbose "$(Get-Date -Format G): `tRetrieving Licensing data"
 	$LSAdminAddress = Get-LicLocation -LicenseServerAddress $Script:XDSite1.LicenseServerName -EA 0 4>$Null
 	If($? -and ($Null -ne $LSAdminAddress))
 	{
@@ -30089,12 +30482,12 @@ Function ProcessLicensing
 		$txt = "Unable to retrieve License Server Admin Address"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputLicensingOverview
 {
-	Write-Verbose "$(Get-Date): `tOutput Licensing Overview"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Licensing Overview"
 
 	#V1.42 added getting the IP address for the license server
 	$LicenseServerIPAddress = Get-IPAddress $Script:XDSite1.LicenseServerName
@@ -30199,13 +30592,18 @@ Function OutputLicensingOverview
 		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "275"
 		WriteHTMLLine 0 0 " "
 	}
+	
+	If($Hardware)
+	{
+		GetComputerWMIInfo $Script:XDSite1.LicenseServerName
+	}
 }
 
 Function OutputXenDesktopLicenses
 {
 	Param([object]$LSAdminAddress, [object]$LSCertificate, [object]$ProductLicenses)
 	
-	Write-Verbose "$(Get-Date): `tOutput Licenses"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Licenses"
 	[int]$NumLicenses = 0
 	
 	ForEach($Product in $ProductLicenses)
@@ -30352,7 +30750,7 @@ Function OutputLicenseAdmins
 {
 	Param([object]$LicenseAdmins)
 	
-	Write-Verbose "$(Get-Date): `tProcessing License Administrators"
+	Write-Verbose "$(Get-Date -Format G): `tProcessing License Administrators"
 
 	$txt = "License Administrators"
 	If($MSWord -or $PDF)
@@ -30380,7 +30778,7 @@ Function OutputLicenseAdmins
 
 	ForEach($Admin in $LicenseAdmins)
 	{
-		Write-Verbose "$(Get-Date): `t`tAdding Administrator $($Admin.Account)"
+		Write-Verbose "$(Get-Date -Format G): `t`tAdding Administrator $($Admin.Account)"
 
 		If($MSWord -or $PDF)
 		{
@@ -30438,7 +30836,7 @@ Function OutputLicenseAdmins
 #region StoreFront functions
 Function ProcessStoreFront
 {
-	Write-Verbose "$(Get-Date): Processing StoreFront"
+	Write-Verbose "$(Get-Date -Format G): Processing StoreFront"
 	
 	$Script:TotalStoreFrontServers = 0
 	
@@ -30456,7 +30854,7 @@ Function ProcessStoreFront
 		WriteHTMLLine 1 0 "StoreFront"
 	}
 	
-	Write-Verbose "$(Get-Date): `tRetrieving StoreFront information"
+	Write-Verbose "$(Get-Date -Format G): `tRetrieving StoreFront information"
 	$SFInfos = Get-BrokerMachineConfiguration @XDParams1 -Name rs* -SortBy LeafName
 	If($? -and ($Null -ne $SFInfos))
 	{
@@ -30466,7 +30864,7 @@ Function ProcessStoreFront
 			$Script:TotalStoreFrontServers++
 
 			$SFByteArray = $SFInfo.Policy
-			Write-Verbose "$(Get-Date): `t`tRetrieving StoreFront server information for $($SFInfo.LeafName)"
+			Write-Verbose "$(Get-Date -Format G): `t`tRetrieving StoreFront server information for $($SFInfo.LeafName)"
 			$SFServer = Get-SFStoreFrontAddress -ByteArray $SFByteArray 4>$Null
 			If($? -and ($Null -ne $SFServer))
 			{
@@ -30486,7 +30884,7 @@ Function ProcessStoreFront
 						OutputStoreFrontDeliveryGroups $SFInfo
 					}
 					
-					Write-Verbose "$(Get-Date): `t`tProcessing administrators for StoreFront server $($SFServer.Name)"
+					Write-Verbose "$(Get-Date -Format G): `t`tProcessing administrators for StoreFront server $($SFServer.Name)"
 					$Admins = GetAdmins "Storefront"
 					
 					If($? -and ($Null -ne $Admins))
@@ -30528,7 +30926,7 @@ Function ProcessStoreFront
 		OutputWarning $txt
 	}
 	
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputStoreFront
@@ -30537,7 +30935,7 @@ Function OutputStoreFront
 	
 	$DGCnt = $SFInfo.DesktopGroupUids.Count
 	
-	Write-Verbose "$(Get-Date): `t`t`tOutput StoreFront server $($SFServer.Name)"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tOutput StoreFront server $($SFServer.Name)"
 	If($MSWord -or $PDF)
 	{
 		WriteWordLine 2 0 "Server: " $SFServer.Name
@@ -30671,7 +31069,7 @@ Function OutputStoreFrontDeliveryGroups
 #region AppV functions
 Function ProcessAppV
 {
-	Write-Verbose "$(Get-Date): Processing App-V"
+	Write-Verbose "$(Get-Date -Format G): Processing App-V"
 	
 	If($MSWord -or $PDF)
 	{
@@ -30687,12 +31085,12 @@ Function ProcessAppV
 		WriteHTMLLine 1 0 "App-V Publishing"
 	}
 	
-	Write-Verbose "$(Get-Date): `tRetrieving App-V configuration"
+	Write-Verbose "$(Get-Date -Format G): `tRetrieving App-V configuration"
 	$AppVConfigs = Get-BrokerMachineConfiguration @XDParams1 -Name appv* 4>$Null
 	
 	If($? -and $Null -ne $AppVConfigs)
 	{
-		Write-Verbose "$(Get-Date): `t`tRetrieving App-V server information"
+		Write-Verbose "$(Get-Date -Format G): `t`tRetrieving App-V server information"
 		
 		$AppVs = @()
 		ForEach($AppVConfig in $AppVConfigs)
@@ -30731,14 +31129,14 @@ Function ProcessAppV
 		$txt = "Unable to retrieve App-V configuration"
 		OutputWarning $txt
 	}
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): "
 }
 
 Function OutputAppV
 {
 	Param([object]$AppVs)
 	
-	Write-Verbose "$(Get-Date): `t`t`tOutput App-V server information"
+	Write-Verbose "$(Get-Date -Format G): `t`t`tOutput App-V server information"
 	If($MSWord -or $PDF)
 	{
 		[System.Collections.Hashtable[]] $AppVWordTable = @();
@@ -30750,7 +31148,7 @@ Function OutputAppV
 	
 	ForEach($AppV in $AppVs)
 	{
-		Write-Verbose "$(Get-Date): `t`t`tAdding AppV Server $($AppV.MgmtServer)"
+		Write-Verbose "$(Get-Date -Format G): `t`t`tAdding AppV Server $($AppV.MgmtServer)"
 
 		If($MSWord -or $PDF)
 		{
@@ -30810,7 +31208,7 @@ Function OutputAppV
 #region zones
 Function ProcessZones
 {
-	Write-Verbose "$(Get-Date): Processing Zones"
+	Write-Verbose "$(Get-Date -Format G): Processing Zones"
 
 	$Script:TotalZones = 0
 
@@ -30829,14 +31227,14 @@ Function ProcessZones
 	}
 	
 	#get all zone names
-	Write-Verbose "$(Get-Date): `tRetrieving All Zones"
+	Write-Verbose "$(Get-Date -Format G): `tRetrieving All Zones"
 	$Zones = Get-ConfigZone @XDParams1 | Sort-Object Name
 	$ZoneMembers = @()
 	
 	ForEach($Zone in $Zones)
 	{
 		$Script:TotalZones++
-		Write-Verbose "$(Get-Date): `t`tRetrieving Machine Catalogs for Zone $($Zone.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`tRetrieving Machine Catalogs for Zone $($Zone.Name)"
 		$ZoneCatalogs = Get-BrokerCatalog @XDParams2 -ZoneUid $Zone.Uid
 		ForEach($ZoneCatalog in $ZoneCatalogs)
 		{
@@ -30850,7 +31248,7 @@ Function ProcessZones
 			$ZoneMembers += $obj
 		}
 		
-		Write-Verbose "$(Get-Date): `t`tRetrieving Delivery Controllers for Zone $($Zone.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`tRetrieving Delivery Controllers for Zone $($Zone.Name)"
 		$ZoneControllers = $Zone.ControllerNames
 		ForEach($ZoneController in $ZoneControllers)
 		{
@@ -30869,7 +31267,7 @@ Function ProcessZones
 			}
 		}
 
-		Write-Verbose "$(Get-Date): `t`tRetrieving Host Connections for Zone $($Zone.Name)"
+		Write-Verbose "$(Get-Date -Format G): `t`tRetrieving Host Connections for Zone $($Zone.Name)"
 		$ZoneHosts = Get-ChildItem @XDParams1 -path 'xdhyp:\connections' 4>$Null | Where-Object {$_.ZoneUid -eq $Zone.Uid}
 		ForEach($ZoneHost in $ZoneHosts)
 		{
@@ -30893,7 +31291,7 @@ Function OutputZoneSiteView
 {
 	Param([array]$ZoneMembers)
 	
-	Write-Verbose "$(Get-Date): `tOutput Zone Site View"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Zone Site View"
 	$ZoneMembers = $ZoneMembers | Sort-Object MemName
 	
 	If($MSWord -or $PDF)
@@ -30974,7 +31372,7 @@ Function OutputPerZoneView
 {
 	Param([array]$ZoneMembers, [object]$Zones)
 	
-	Write-Verbose "$(Get-Date): `tOutput Per Zone View"
+	Write-Verbose "$(Get-Date -Format G): `tOutput Per Zone View"
 	$ZoneMembers = $ZoneMembers | Sort-Object MemZone, MemName
 
 	ForEach($Zone in $Zones)
@@ -31059,7 +31457,7 @@ Function OutputPerZoneView
 Function ProcessSummaryPage
 {
 	#summary page
-	Write-Verbose "$(Get-Date): Create Summary Page"
+	Write-Verbose "$(Get-Date -Format G): Create Summary Page"
 	
 	If($MSWord -or $PDF)
 	{
@@ -31076,24 +31474,24 @@ Function ProcessSummaryPage
 		WriteHTMLLine 1 0 "XenDesktop $($Script:XDSiteVersionReal) $($XDSiteName) Summary Page"
 	}
 
-	Write-Verbose "$(Get-Date): `tAdd administrator summary info"
+	Write-Verbose "$(Get-Date -Format G): `tAdd administrator summary info"
 	If($MSWord -or $PDF)
 	{
-		Write-Verbose "$(Get-Date): `tAdd Machine Catalog summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Machine Catalog summary info"
 		WriteWordLine 0 0 "Machine Catalogs"
 		WriteWordLine 0 1 "Total Server OS Catalogs`t: " $Script:TotalServerOSCatalogs
 		WriteWordLine 0 1 "Total Desktop OS Catalogs`t: " $Script:TotalDesktopOSCatalogs
 		WriteWordLine 0 1 "Total RemotePC Catalogs`t: " $Script:TotalRemotePCCatalogs
 		WriteWordLine 0 2 "Total Machine Catalogs`t: " ($Script:TotalServerOSCatalogs+$Script:TotalDesktopOSCatalogs+$Script:TotalRemotePCCatalogs)
 		WriteWordLine 0 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Delivery Group summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Delivery Group summary info"
 		WriteWordLine 0 0 "Delivery Groups"
 		WriteWordLine 0 1 "Total Application Groups`t: " $Script:TotalApplicationGroups
 		WriteWordLine 0 1 "Total Desktop Groups`t`t: " $Script:TotalDesktopGroups
 		WriteWordLine 0 1 "Total Apps & Desktop Groups`t: " $Script:TotalAppsAndDesktopGroups
 		WriteWordLine 0 2 "Total Delivery Groups`t: " ($Script:TotalApplicationGroups+$Script:TotalDesktopGroups+$Script:TotalAppsAndDesktopGroups)
 		WriteWordLine 0 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Application summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Application summary info"
 		WriteWordLine 0 0 "Applications"
 		WriteWordLine 0 1 "Total Published Applications`t: " $Script:TotalPublishedApplications
 		WriteWordLine 0 1 "Total App-V Applications`t: " $Script:TotalAppvApplications
@@ -31102,7 +31500,7 @@ Function ProcessSummaryPage
 		
 		If($Policies -eq $True)
 		{
-			Write-Verbose "$(Get-Date): `tAdd Policy summary info"
+			Write-Verbose "$(Get-Date -Format G): `tAdd Policy summary info"
 			WriteWordLine 0 0 "Policies"
 			WriteWordLine 0 1 "Total Computer Policies`t`t: " $Script:TotalComputerPolicies
 			WriteWordLine 0 1 "Total User Policies`t`t: " $Script:TotalUserPolicies
@@ -31128,15 +31526,15 @@ Function ProcessSummaryPage
 		WriteWordLine 0 1 "Total Custom Admins`t`t: " $Script:TotalCustomAdmins
 		WriteWordLine 0 2 "Total Administrators`t: " ($Script:TotalDeliveryGroupAdmins+$Script:TotalFullAdmins+$Script:TotalHelpDeskAdmins+$Script:TotalHostAdmins+$Script:TotalMachineCatalogAdmins+$Script:TotalReadOnlyAdmins+$Script:TotalCustomAdmins)
 		WriteWordLine 0 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Controller summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Controller summary info"
 		WriteWordLine 0 0 "Controllers"
 		WriteWordLine 0 1 "Total Controllers`t`t: " $Script:TotalControllers
 		WriteWordLine 0 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Hosting Connection summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Hosting Connection summary info"
 		WriteWordLine 0 0 "Hosting Connections"
 		WriteWordLine 0 1 "Total Hosting Connections`t: " $Script:TotalHostingConnections
 		WriteWordLine 0 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Licensing summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Licensing summary info"
 		WriteWordLine 0 0 "Licensing"
 		$TotalLicenses = 0
 		ForEach($License in $Script:Licenses)
@@ -31146,34 +31544,34 @@ Function ProcessSummaryPage
 		}
 		WriteWordLine 0 2 "Total Licenses`t`t: " $TotalLicenses
 		WriteWordLine 0 0 ""
-		Write-Verbose "$(Get-Date): `tAdd StoreFront summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd StoreFront summary info"
 		WriteWordLine 0 0 "StoreFront"
 		WriteWordLine 0 1 "Total StoreFront Servers`t: " $Script:TotalStoreFrontServers
 		WriteWordLine 0 0 ""
 		If((Get-ConfigServiceAddedCapability @XDParams1) -contains "ZonesSupport")
 		{
-			Write-Verbose "$(Get-Date): `tAdd Zone summary info"
+			Write-Verbose "$(Get-Date -Format G): `tAdd Zone summary info"
 			WriteWordLine 0 0 "Zones"
 			WriteWordLine 0 1 "Total Zones`t`t`t: " $Script:TotalZones
 		}
 	}
 	ElseIf($Text)
 	{
-		Write-Verbose "$(Get-Date): `tAdd Machine Catalog summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Machine Catalog summary info"
 		Line 0 "Machine Catalogs"
 		Line 1 "Total Server OS Catalogs`t: " $Script:TotalServerOSCatalogs
 		Line 1 "Total Desktop OS Catalogs`t: " $Script:TotalDesktopOSCatalogs
 		Line 1 "Total RemotePC Catalogs`t`t: " $Script:TotalRemotePCCatalogs
 		Line 2 "Total Machine Catalogs`t: " ($Script:TotalServerOSCatalogs+$Script:TotalDesktopOSCatalogs+$Script:TotalRemotePCCatalogs)
 		Line 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Delivery Group summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Delivery Group summary info"
 		Line 0 "Delivery Groups"
 		Line 1 "Total Application Groups`t: " $Script:TotalApplicationGroups
 		Line 1 "Total Desktop Groups`t`t: " $Script:TotalDesktopGroups
 		Line 1 "Total Apps & Desktop Groups`t: " $Script:TotalAppsAndDesktopGroups
 		Line 2 "Total Delivery Groups`t: " ($Script:TotalApplicationGroups+$Script:TotalDesktopGroups+$Script:TotalAppsAndDesktopGroups)
 		Line 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Application summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Application summary info"
 		Line 0 "Applications"
 		Line 1 "Total Published Applications`t: " $Script:TotalPublishedApplications
 		Line 1 "Total App-V Applications`t: " $Script:TotalAppvApplications
@@ -31182,7 +31580,7 @@ Function ProcessSummaryPage
 		
 		If($Policies -eq $True)
 		{
-			Write-Verbose "$(Get-Date): `tAdd Policy summary info"
+			Write-Verbose "$(Get-Date -Format G): `tAdd Policy summary info"
 			Line 0 "Policies"
 			Line 1 "Total Computer Policies`t`t: " $Script:TotalComputerPolicies
 			Line 1 "Total User Policies`t`t: " $Script:TotalUserPolicies
@@ -31208,15 +31606,15 @@ Function ProcessSummaryPage
 		Line 1 "Total Custom Admins`t`t: " $Script:TotalCustomAdmins
 		Line 2 "Total Administrators`t: " ($Script:TotalDeliveryGroupAdmins+$Script:TotalFullAdmins+$Script:TotalHelpDeskAdmins+$Script:TotalHostAdmins+$Script:TotalMachineCatalogAdmins+$Script:TotalReadOnlyAdmins+$Script:TotalCustomAdmins)
 		Line 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Controller summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Controller summary info"
 		Line 0 "Controllers"
 		Line 1 "Total Controllers`t`t: " $Script:TotalControllers
 		Line 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Hosting Connection summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Hosting Connection summary info"
 		Line 0 "Hosting Connections"
 		Line 1 "Total Hosting Connections`t: " $Script:TotalHostingConnections
 		Line 0 ""
-		Write-Verbose "$(Get-Date): `tAdd Licensing summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Licensing summary info"
 		Line 0 "Licensing"
 		$TotalLicenses = 0
 		ForEach($License in $Script:Licenses)
@@ -31226,34 +31624,34 @@ Function ProcessSummaryPage
 		}
 		Line 2 "Total Licenses`t`t: " $TotalLicenses
 		Line 0 ""
-		Write-Verbose "$(Get-Date): `tAdd StoreFront summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd StoreFront summary info"
 		Line 0 "StoreFront"
 		Line 1 "Total StoreFront Servers`t: " $Script:TotalStoreFrontServers
 		Line 0 ""
 		If((Get-ConfigServiceAddedCapability @XDParams1) -contains "ZonesSupport")
 		{
-			Write-Verbose "$(Get-Date): `tAdd Zone summary info"
+			Write-Verbose "$(Get-Date -Format G): `tAdd Zone summary info"
 			Line 0 "Zones"
 			Line 1 "Total Zones`t`t`t: " $Script:TotalZones
 		}
 	}
 	ElseIf($HTML)
 	{
-		Write-Verbose "$(Get-Date): `tAdd Machine Catalog summary info"
+		Write-Verbose "$(Get-Date -Format G): `tAdd Machine Catalog summary info"
 		WriteHTMLLine 0 0 "Machine Catalogs"
 		WriteHTMLLine 0 1 "Total Server OS Catalogs: " $Script:TotalServerOSCatalogs
 		WriteHTMLLine 0 1 "Total Desktop OS Catalogs: " $Script:TotalDesktopOSCatalogs
 		WriteHTMLLine 0 1 "Total RemotePC Catalogs: " $Script:TotalRemotePCCatalogs
 		WriteHTMLLine 0 2 "Total Machine Catalogs: " ($Script:TotalServerOSCatalogs+$Script:TotalDesktopOSCatalogs+$Script:TotalRemotePCCatalogs)
 		WriteHTMLLine 0 0 ""
-		Write-Verbose "$(Get-Date): Add Delivery Group summary info"
+		Write-Verbose "$(Get-Date -Format G): Add Delivery Group summary info"
 		WriteHTMLLine 0 0 "Delivery Groups"
 		WriteHTMLLine 0 1 "Total Application Groups: " $Script:TotalApplicationGroups
 		WriteHTMLLine 0 1 "Total Desktop Groups: " $Script:TotalDesktopGroups
 		WriteHTMLLine 0 1 "Total Apps & Desktop Groups: " $Script:TotalAppsAndDesktopGroups
 		WriteHTMLLine 0 2 "Total Delivery Groups: " ($Script:TotalApplicationGroups+$Script:TotalDesktopGroups+$Script:TotalAppsAndDesktopGroups)
 		WriteHTMLLine 0 0 ""
-		Write-Verbose "$(Get-Date): Add Application summary info"
+		Write-Verbose "$(Get-Date -Format G): Add Application summary info"
 		WriteHTMLLine 0 0 "Applications"
 		WriteHTMLLine 0 1 "Total Published Applications: " $Script:TotalPublishedApplications
 		WriteHTMLLine 0 1 "Total App-V Applications: " $Script:TotalAppvApplications
@@ -31262,7 +31660,7 @@ Function ProcessSummaryPage
 		
 		If($Policies -eq $True)
 		{
-			Write-Verbose "$(Get-Date): Add Policy summary info"
+			Write-Verbose "$(Get-Date -Format G): Add Policy summary info"
 			WriteHTMLLine 0 0 "Policies"
 			WriteHTMLLine 0 1 "Total Computer Policies: " $Script:TotalComputerPolicies
 			WriteHTMLLine 0 1 "Total User Policies: " $Script:TotalUserPolicies
@@ -31288,15 +31686,15 @@ Function ProcessSummaryPage
 		WriteHTMLLine 0 1 "Total Custom Admins: " $Script:TotalCustomAdmins
 		WriteHTMLLine 0 2 "Total Administrators: " ($Script:TotalDeliveryGroupAdmins+$Script:TotalFullAdmins+$Script:TotalHelpDeskAdmins+$Script:TotalHostAdmins+$Script:TotalMachineCatalogAdmins+$Script:TotalReadOnlyAdmins+$Script:TotalCustomAdmins)
 		WriteHTMLLine 0 0 ""
-		Write-Verbose "$(Get-Date): Add Controller summary info"
+		Write-Verbose "$(Get-Date -Format G): Add Controller summary info"
 		WriteHTMLLine 0 0 "Controllers"
 		WriteHTMLLine 0 1 "Total Controllers: " $Script:TotalControllers
 		WriteHTMLLine 0 0 ""
-		Write-Verbose "$(Get-Date): Add Hosting Connection summary info"
+		Write-Verbose "$(Get-Date -Format G): Add Hosting Connection summary info"
 		WriteHTMLLine 0 0 "Hosting Connections"
 		WriteHTMLLine 0 1 "Total Hosting Connections: " $Script:TotalHostingConnections
 		WriteHTMLLine 0 0 ""
-		Write-Verbose "$(Get-Date): Add Licensing summary info"
+		Write-Verbose "$(Get-Date -Format G): Add Licensing summary info"
 		WriteHTMLLine 0 0 "Licensing"
 		$TotalLicenses = 0
 		ForEach($License in $Script:Licenses)
@@ -31306,20 +31704,20 @@ Function ProcessSummaryPage
 		}
 		WriteHTMLLine 0 2 "Total Licenses: " $TotalLicenses
 		WriteHTMLLine 0 0 ""
-		Write-Verbose "$(Get-Date): Add StoreFront summary info"
+		Write-Verbose "$(Get-Date -Format G): Add StoreFront summary info"
 		WriteHTMLLine 0 0 "StoreFront"
 		WriteHTMLLine 0 1 "Total StoreFront Servers: " $Script:TotalStoreFrontServers
 		WriteHTMLLine 0 0 ""
 		If((Get-ConfigServiceAddedCapability @XDParams1) -contains "ZonesSupport")
 		{
-			Write-Verbose "$(Get-Date): Add Zone summary info"
+			Write-Verbose "$(Get-Date -Format G): Add Zone summary info"
 			WriteHTMLLine 0 0 "Zones"
 			WriteHTMLLine 0 1 "Total Zones: " $Script:TotalZones
 		}
 	}
 
-	Write-Verbose "$(Get-Date): Finished Create Summary Page"
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): Finished Create Summary Page"
+	Write-Verbose "$(Get-Date -Format G): "
 }
 #endregion
 
@@ -31463,7 +31861,7 @@ Function ProcessScriptSetup
 	$Script:DoPolicies = $True
 	If($NoPolicies)
 	{
-		Write-Verbose "$(Get-Date): NoPolicies was specified so do not search for Citrix.GroupPolicy.Commands.psm1"
+		Write-Verbose "$(Get-Date -Format G): NoPolicies was specified so do not search for Citrix.GroupPolicy.Commands.psm1"
 		$Script:DoPolicies = $False
 	}
 	ElseIf(!(Check-LoadedModule "Citrix.GroupPolicy.Commands") -and $Policies -eq $False)
@@ -31475,7 +31873,7 @@ Function ProcessScriptSetup
 	(https://carlwebster.sharefile.com/d-sc33767b127542c89). 
 	`n`n
 	Citrix Policy documentation will not take place"
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		$Script:DoPolicies = $False
 	}
 	ElseIf(!(Check-LoadedModule "Citrix.GroupPolicy.Commands") -and $Policies -eq $True)
@@ -31490,7 +31888,7 @@ Function ProcessScriptSetup
 	Because the Policies parameter was used the script will now close.
 	`n`n
 	"
-		Write-Verbose "$(Get-Date): "
+		Write-Verbose "$(Get-Date -Format G): "
 		Exit
 	}
 	
@@ -31525,7 +31923,7 @@ Function ProcessScriptSetup
 	}
 
 	# Get Site information
-	Write-Verbose "$(Get-Date): Gathering initial Site data"
+	Write-Verbose "$(Get-Date -Format G): Gathering initial Site data"
 
 	$Script:XDSite1 = Get-BrokerSite @XDParams1
 
@@ -31671,22 +32069,22 @@ Function ProcessScriptSetup
 		"Zones" 		{[string]$Script:Title = "Inventory Report for the $($Script:XDSiteName) Site (Zones Only)"; Break}
 		"All" 			{[string]$Script:Title = "Inventory Report for the $($Script:XDSiteName) Site"; Break}
 	}
-	Write-Verbose "$(Get-Date): Initial Site data has been gathered"
+	Write-Verbose "$(Get-Date -Format G): Initial Site data has been gathered"
 	
 	#added 25-Jun-2017 with a lot of help from Michael B. Smith
 	#make sure the SQL Server assembly is loaded, if not, later on don't bother calculating the various database sizes
-	Write-Verbose "$(Get-Date): Loading SQL Server Assembly"
+	Write-Verbose "$(Get-Date -Format G): Loading SQL Server Assembly"
 	[bool]$Script:SQLServerLoaded = $False
 	
 	$asm = [reflection.assembly]::loadwithpartialname('microsoft.sqlserver.smo')
 	If( $null –eq $asm )
 	{
-		Write-Verbose "$(Get-Date): `tSQL Server Assembly could not be loaded"
+		Write-Verbose "$(Get-Date -Format G): `tSQL Server Assembly could not be loaded"
 		$Script:SQLServerLoaded = $False
 	}
 	Else
 	{
-		Write-Verbose "$(Get-Date): `tSQL Server Assembly successefully loaded"
+		Write-Verbose "$(Get-Date -Format G): `tSQL Server Assembly successefully loaded"
 		$Script:SQLServerLoaded = $True
 	}
 }
@@ -31695,12 +32093,12 @@ Function ProcessScriptSetup
 #region script end
 Function ProcessScriptEnd
 {
-	Write-Verbose "$(Get-Date): Script has completed"
-	Write-Verbose "$(Get-Date): "
+	Write-Verbose "$(Get-Date -Format G): Script has completed"
+	Write-Verbose "$(Get-Date -Format G): "
 
 	#http://poshtips.com/measuring-elapsed-time-in-powershell/
-	Write-Verbose "$(Get-Date): Script started: $($Script:StartTime)"
-	Write-Verbose "$(Get-Date): Script ended: $(Get-Date)"
+	Write-Verbose "$(Get-Date -Format G): Script started: $($Script:StartTime)"
+	Write-Verbose "$(Get-Date -Format G): Script ended: $(Get-Date)"
 	$runtime = $(Get-Date) - $Script:StartTime
 	$Str = [string]::format("{0} days, {1} hours, {2} minutes, {3}.{4} seconds", `
 		$runtime.Days, `
@@ -31708,7 +32106,7 @@ Function ProcessScriptEnd
 		$runtime.Minutes, `
 		$runtime.Seconds,
 		$runtime.Milliseconds)
-	Write-Verbose "$(Get-Date): Elapsed time: $($Str)"
+	Write-Verbose "$(Get-Date -Format G): Elapsed time: $($Str)"
 	If($Dev)
 	{
 		If($SmtpServer -eq "")
@@ -31808,11 +32206,11 @@ Function ProcessScriptEnd
 			try 
 			{
 				Stop-Transcript | Out-Null
-				Write-Verbose "$(Get-Date): $Script:LogPath is ready for use"
+				Write-Verbose "$(Get-Date -Format G): $Script:LogPath is ready for use"
 			} 
 			catch 
 			{
-				Write-Verbose "$(Get-Date): Transcript/log stop failed"
+				Write-Verbose "$(Get-Date -Format G): Transcript/log stop failed"
 			}
 		}
 	}
@@ -31915,7 +32313,7 @@ If($Section -eq "All")
 #endregion
 
 #region finish script
-Write-Verbose "$(Get-Date): Finishing up document"
+Write-Verbose "$(Get-Date -Format G): Finishing up document"
 #end of document processing
 
 $AbstractTitle = "Citrix XenDesktop $($Script:XDSiteVersion) Inventory"

--- a/XD7_Inventory_V1_ReadMe.rtf
+++ b/XD7_Inventory_V1_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -77,15 +77,15 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \'01\u-3913 ?;}{\levelnumbers;}\f3\fbias0\hres0\chhres0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers
 ;}\f2\fbias0\hres0\chhres0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}
 \f10\fbias0\hres0\chhres0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589\listoverridecount0\ls2}{\listoverride\listid319386001
-\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid2070\rsid219208\rsid265763\rsid677819\rsid1076041\rsid1146462\rsid1654655\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3557177\rsid3761251\rsid3830441\rsid3831187\rsid4619633\rsid4925376\rsid5267713
-\rsid6053627\rsid6237392\rsid6258287\rsid6509366\rsid6885713\rsid7282340\rsid7367214\rsid7687390\rsid7746862\rsid7763859\rsid7809154\rsid7892821\rsid8394203\rsid8410782\rsid8473952\rsid8928184\rsid9112866\rsid9186743\rsid9372083\rsid9380266\rsid9644665
-\rsid9648170\rsid9986361\rsid10033903\rsid10638569\rsid11148983\rsid11353962\rsid11410367\rsid11488686\rsid11551746\rsid11809962\rsid12216897\rsid12256862\rsid12801149\rsid13248665\rsid13308089\rsid13663721\rsid13853169\rsid13987238\rsid14298582
-\rsid14300739\rsid14697282\rsid14881286\rsid15028178\rsid15424297\rsid15739805\rsid15757842\rsid15955795\rsid16207041\rsid16267726\rsid16269241\rsid16283129\rsid16408172\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0
-\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo1\dy24\hr15\min48}{\version47}{\edmins11785}{\nofpages28}{\nofwords8470}{\nofchars48282}
-{\nofcharsws56639}{\vern15}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\listoverridecount0\ls3}}{\*\revtbl {Unknown;}}{\*\rsidtbl \rsid2070\rsid219208\rsid265763\rsid677819\rsid1076041\rsid1146462\rsid1654655\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3557177\rsid3761251\rsid3830441\rsid3831187\rsid4143801\rsid4619633\rsid4925376
+\rsid5267713\rsid6053627\rsid6237392\rsid6258287\rsid6509366\rsid6885713\rsid7282340\rsid7367214\rsid7687390\rsid7746862\rsid7763859\rsid7809154\rsid7892821\rsid8394203\rsid8410782\rsid8473952\rsid8928184\rsid9112866\rsid9186743\rsid9372083\rsid9380266
+\rsid9644665\rsid9648170\rsid9986361\rsid10033903\rsid10638569\rsid11148983\rsid11353962\rsid11410367\rsid11488686\rsid11551746\rsid11809962\rsid12216897\rsid12256862\rsid12801149\rsid13248665\rsid13308089\rsid13663721\rsid13853169\rsid13987238
+\rsid14298582\rsid14300739\rsid14697282\rsid14881286\rsid15028178\rsid15424297\rsid15739805\rsid15757842\rsid15955795\rsid16207041\rsid16267726\rsid16269241\rsid16283129\rsid16408172\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
+\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2021\mo1\dy30\hr9\min31}{\version48}{\edmins11787}{\nofpages28}{\nofwords8479}{\nofchars48334}
+{\nofcharsws56700}{\vern15}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
-{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MTQ3MDQzN7I0MTY0MDVQ0lEKTi0uzszPAykwqQUAkphj8SwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
+{\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MTQ3MDQzN7I0MTY0MDVQ0lEKTi0uzszPAykwrQUA06l46CwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -172,7 +172,7 @@ MachineCreation_PowerShellSnapIn_x??
 {\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041 
 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b84000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0073006800610072006500660069006c0065002e0063006f006d002f0064002d0073003500320036003300
-3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000020f700200032}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid1076041\charrsid1076041 \hich\af37\dbch\af31505\loch\f37 
+3400620034006100370036006300340066006100320061000000795881f43b1d7f48af2c825dc485276300000000a5ab0003000020f70020003200}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid1076041\charrsid1076041 \hich\af37\dbch\af31505\loch\f37 
 https://carlwebster.sharefile.com/d-s52634b4a76c4fa2a}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid1076041\charrsid1076041 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 ii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid16597410\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the file to your default download folder.}{
@@ -202,20 +202,20 @@ Current\\Utilities
 \hich\af43\dbch\af31505\loch\f43  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 Citrix.GroupPolicy.Commands.psm1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 to }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\Modules}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 , in a new folder named }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 
-Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 . This sho\hich\af37\dbch\af31505\loch\f37 uld be placed on the computer where the script is run.
+Citrix.GroupPolicy.Commands}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid16597410 \hich\af37\dbch\af31505\loch\f37 . This should be placed on the \hich\af37\dbch\af31505\loch\f37 computer where the script is run.
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 Note:}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  The Citrix.GroupPolicy.Commands.psm1 file is }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \b\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 not}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
  the version that comes with XenApp 6.5. This is an updated version that comes }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16207041 \hich\af37\dbch\af31505\loch\f37 installed with XenDesktop 7.x or }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.ci\hich\af37\dbch\af31505\loch\f37 
-trix.com/article/CTX130147" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
+\f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 with }{\field\flddirty{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://support.citrix.com/article/CTX1
+\hich\af37\dbch\af31505\loch\f37 30147" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7000000068007400740070003a002f002f0073007500700070006f00720074002e006300690074007200690078002e0063006f006d002f00610072007400690063006c0065002f004300540058003100330030003100
-340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000000000000000000000000080000800000000070000000003f00000000006afb000039}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 
+340037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000fe00000000000000000000000000080000800000000070000000003f00000000006afb00003900}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid9112866\charrsid2579094 
 \hich\af37\dbch\af31505\loch\f37 Citrix Scout}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2070 \hich\af37\dbch\af31505\loch\f37  }{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 The XenApp 6.5 file is from September 2011}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 ,}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37  the updated version is from Ju}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 ne}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
-\hich\af37\dbch\af31505\loch\f37  \hich\af37\dbch\af31505\loch\f37 2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
-\hich\af37\dbch\af31505\loch\f37 The updated version allows the policy cmdlets to be run against a remote Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 
+\hich\af37\dbch\af31505\loch\f37  2014}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9986361 \hich\af37\dbch\af31505\loch\f37 . }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 \hich\af37\dbch\af31505\loch\f37 
+The updated version allows the policy cmdlets to be run against a remote Controller.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37 
  You cannot use the updated version to run against a remote XenApp 6.5 Collector.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866\charrsid12801149 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid9112866 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf23\insrsid16597410 \hich\af43\dbch\af31505\loch\f43 
@@ -226,7 +226,7 @@ Script Usage
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 X}{\rtlch\fcs1 
 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventory.ps1 }{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 in your PowerShell scripts folder.
+\ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 in your Powe\hich\af37\dbch\af31505\loch\f37 rShell scripts folder.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, change to your PowerShell scripts}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13853169 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 3.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, type in:
@@ -236,9 +236,8 @@ Script Usage
 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 and press }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Enter}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 4.\tab}}\pard \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 
-By default, a Microsoft Word document is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid11488686\charrsid13987238 .
+\nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 By default, a Micr\hich\af37\dbch\af31505\loch\f37 
+osoft Word document is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 5.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash \loch\f37 
 PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
@@ -246,11 +245,12 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \nowidctlpar\wrapdefault\faauto\ls3\rin0\lin720\itap0\pararsid16517051\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 HTML}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, a}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 n HTML}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Deskt\hich\af37\dbch\af31505\loch\f37 op 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 7.\tab}\hich\af37\dbch\af31505\loch\f37 If you use the \hich\f37 \endash }{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, a }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid16517051 
+\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 7.\tab}\hich\af37\dbch\af31505\loch\f37 If\hich\af37\dbch\af31505\loch\f37  you use the \hich\f37 \endash }{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  option, a }{\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Text}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 \hich\af37\dbch\af31505\loch\f37  file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 Desktop 7.x Site}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid13987238 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051\charrsid16517051 
+
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 To }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 run}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37  the script }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 against a remote Controller:
@@ -262,7 +262,7 @@ PDF option, a PDF file is created named after the Xen}{\rtlch\fcs1 \af37\afs22 \
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid16517051 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\X}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 _In\hich\af37\dbch\af31505\loch\f37 ventory.ps1 \hich\f37 \endash \loch\f37 full
+\f37\fs22\insrsid16517051 \hich\af37\dbch\af31505\loch\f37 D7}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 _Inventory.ps1 \hich\f37 \endash \loch\f37 full
 \par 
 \par \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid7282340 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
@@ -283,109 +283,108 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Administrators] }{\rtlch\fcs1 \af2\
 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-\hich\af2\dbch\af31505\loch\f2 NoPolicies] [-NoSessions] [-Policies] }{
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-NoPolicies] [-NoSessions] [-Policies] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-StoreFront] [-MaxDeta\hich\af2\dbch\af31505\loch\f2 ils]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-MSWord] [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>\hich\af2\dbch\af31505\loch\f2 
+] [-UserName <String>] [-SmtpServer <String>] [-SmtpPort <Int32>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-From <String>] [-To}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-UseSSL] [<CommonParameters>]
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory.ps1 [-AdminAddress <String>] [-HTML] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGrou\hich\af2\dbch\af31505\loch\f2 ps] [-DeliveryGroupsUtilization] [-Hardware] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-NoPolicies] [-NoSessions] [-Policies] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-StoreFront] [-MaxDetails]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-Add\hich\af2\dbch\af31505\loch\f2 DateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-SmtpServer <String>] [-SmtpPort <Int32>] [-From }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-To <String>] [-UseSSL] [<CommonParameters>]
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory.ps1 [-AdminAddress <String>] [-Text] [-Administrato\hich\af2\dbch\af31505\loch\f2 rs] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-NoPolicies] [-NoSessions] [-Policies] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-StoreFront] \hich\af2\dbch\af31505\loch\f2 [-MaxDetails]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-SmtpServer <String>] [-SmtpPort <Int32>] [-From }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-To <String>] [-UseSSL] [<CommonParameters>]
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \\\hich\af2\dbch\af31505\loch\f2 
+XD7_Inventory.ps1 [-AdminA\hich\af2\dbch\af31505\loch\f2 ddress <String>] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-NoPolicies] [-NoSessions] \hich\af2\dbch\af31505\loch\f2 [-Policies] }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-StoreFront] [-MaxDetails]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-MSWord] [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-PDF] [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <Stri\hich\af2\dbch\af31505\loch\f2 
-ng>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-SmtpServer <String>] [-SmtpPort <Int32>] }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-From <String>] [-To}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-UseSSL] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory.ps1 [-AdminAddress <String>] [-HTML] [-Admi\hich\af2\dbch\af31505\loch\f2 nistrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-NoPolicies] [-NoSessions] [-Policies] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-StoreFront] [-MaxDetails\hich\af2\dbch\af31505\loch\f2 ]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-SmtpServer <String>] [-SmtpPort <Int32>] [-From }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-To <String>] [-UseSSL] [<CommonParameters>]
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 C:\\PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \\\hich\af2\dbch\af31505\loch\f2 
-XD7_Inventory.ps1 [-AdminAddress <String>] [-T\hich\af2\dbch\af31505\loch\f2 ext] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-NoPolicies] [-NoSessions] [-Policies] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-StoreFront] [\hich\af2\dbch\af31505\loch\f2 -MaxDetails]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-SmtpServer <String>] [-SmtpPort <Int32>] [-From }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-To <String>] [-UseSSL] [<CommonParameters>]
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 C:\\P\hich\af2\dbch\af31505\loch\f2 SScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \\
-\hich\af2\dbch\af31505\loch\f2 XD7_Inventory.ps1 [-AdminAddress <S\hich\af2\dbch\af31505\loch\f2 tring>] [-Administrators] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Applications] [-DeliveryGroups] [-DeliveryGroupsUtilization] [-Hardware] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Hosting] [-Logging] [-StartDate <DateTime>] [-EndDate <DateTime>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-MachineCatalogs] [-NoADPolicies] [-NoPolicies] [-NoSessions] [-Policies] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-StoreFront\hich\af2\dbch\af31505\loch\f2 ] [-MaxDetails]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-Section <String>] [-AddDateTime] [-Dev] [-Folder }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-Log] [-ScriptInfo] [-PDF] [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [\hich\af2\dbch\af31505\loch\f2 
--UserName <String>] [-SmtpServer <String>] [-SmtpPort <Int32>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 [-From <String>] [-To}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 <String>] [-UseSSL] [<CommonParameters>]
-\par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
-\par \hich\af2\dbch\af31505\loch\f2     Creates an inventory of a Citrix XenDesktop 7.0 through 7.7 Site using Microsoft
-\par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain\hich\af2\dbch\af31505\loch\f2  text, or HTML.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    Creates an inventory of a Citrix XenDesktop 7.0 through 7.7 Site using Microsoft
+\par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text, or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This script requires at least PowerShell version 3 but runs best in version 5.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script outputs in Text and HTML.
+\par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. Th\hich\af2\dbch\af31505\loch\f2 is script outputs in Text and HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 8.1 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the -AdminAddr\hich\af2\dbch\af31505\loch\f2 ess (AA) parameter.
+\par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the -AdminAddress (AA) parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This script supports versions of XenApp/XenDesktop from 7.0 to 7.7.
+\par \hich\af2\dbch\af31505\loch\f2     This script support\hich\af2\dbch\af31505\loch\f2 s versions of XenApp/XenDesktop from 7.0 to 7.7.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If you are running XA/XD 7.8 through CVAD 2006, please use:
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK \hich\af2\dbch\af31505\loch\f2 
-"https://carlwebster.com/downloads/download-info/xenappxendesktop-7-8/"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/xenappxendesktop-7-8/" }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-8/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14300739\charrsid14300739 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If you are running \hich\af2\dbch\af31505\loch\f2 CVAD 2006 and later, please use:\hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2     
-\hich\af2\dbch\af31505\loch\f2   }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
-HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-virtual-apps-and-desktops-v3-script/"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     If you are running CVAD 2006 and later, please use:    }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2       }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-virtual-apps-and-desktops-v3-script/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+{\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd0000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d00760033002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}
-}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-virtual-apps-and-desktops-v3-script/}}}\sectd \ltrsect
+64002d0069006e0066006f002f006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d00760033002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}
+}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-virtual-apps-and-desktops-v3-script/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If you are running Citrix Cloud, please use:\hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  
-\hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-\hich\af2\dbch\af31505\loch\f2 and-desktops-service/"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     If you are running Citrix Cloud, please use:    }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-d\hich\af2\dbch\af31505\loch\f2 esktops-service/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be6000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
 64002d0069006e0066006f002f006300690074007200690078002d0063006c006f00750064002d006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d0073006500720076006900630065002f000000795881
-f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtu
-\hich\af2\dbch\af31505\loch\f2 al-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
+f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-cloud-citr
+\hich\af2\dbch\af31505\loch\f2 ix-virtual-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
@@ -405,28 +404,28 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
-\par \hich\af2\dbch\af31505\loch\f2         StoreFront
+\par \hich\af2\dbch\af31505\loch\f2         Sto\hich\af2\dbch\af31505\loch\f2 reFront
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using t\hich\af2\dbch\af31505\loch\f2 he MachineCatalogs parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
-\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an \hich\af2\dbch\af31505\loch\f2 extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     complete \hich\af2\dbch\af31505\loch\f2 and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
 \par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to complete and generate an exceptionally long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7\hich\af2\dbch\af31505\loch\f2 .x Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.x Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
 \hich\af2\dbch\af31505\loch\f2  and Footer.
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
-\par \hich\af2\dbch\af31505\loch\f2         Danish
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
-\par \hich\af2\dbch\af31505\loch\f2         Finnis\hich\af2\dbch\af31505\loch\f2 h
+\par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
@@ -437,14 +436,14 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
 \par \hich\af2\dbch\af31505\loch\f2     -AdminAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShell snapins \hich\af2\dbch\af31505\loch\f2 connect}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 s}{
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller th\hich\af2\dbch\af31505\loch\f2 e PowerShell snapins connect}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 s}{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 .
 \par \hich\af2\dbch\af31505\loch\f2         This can be provided as a host name or an IP address.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to LocalHost.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?             \hich\af2\dbch\af31505\loch\f2        named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -456,34 +455,53 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?\hich\af2\dbch\af31505\loch\f2        false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?\hich\af2\dbch\af31505\loch\f2                     named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Administrators [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed informat\hich\af2\dbch\af31505\loch\f2 ion for Administrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Administrator Scopes a\hich\af2\dbch\af31505\loch\f2 nd Roles.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Admins.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value              \hich\af2\dbch\af31505\loch\f2   False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Applications [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all applications.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parame\hich\af2\dbch\af31505\loch\f2 ter has an alias of Apps.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disab\hich\af2\dbch\af31505\loch\f2 led by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Apps.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcar\hich\af2\dbch\af31505\loch\f2 d characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all desktops in all Desktop (Delivery) Groups.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
+\par \hich\af2\dbch\af31505\loch\f2         time to complet\hich\af2\dbch\af31505\loch\f2 e and can generate an extremely long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
+\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         long report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This para\hich\af2\dbch\af31505\loch\f2 meter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -491,79 +509,60 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroups [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all desktops in all Desktop (Delivery) Groups.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroups parameter can cause the report to take a very long
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        time to complete and can generate an extremely long report.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2         report to take an extremely long time to complete and generate an exceptionally
-\par \hich\af2\dbch\af31505\loch\f2         long repo\hich\af2\dbch\af31505\loch\f2 rt.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DG.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input? \hich\af2\dbch\af31505\loch\f2       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     -DeliveryGroupsUtilization [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Gives a chart with the delivery group utilization for the last 7 days
-\par \hich\af2\dbch\af31505\loch\f2         depending on the information in the database.
+\par \hich\af2\dbch\af31505\loch\f2         depending on the information in \hich\af2\dbch\af31505\loch\f2 the database.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This option is only available when the report is generated in Word and requires
 \par \hich\af2\dbch\af31505\loch\f2         Micosoft Excel to be locally installed.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the DeliveryGroupsUtilization parameter causes the report to take a longer
-\par \hich\af2\dbch\af31505\loch\f2         time to complete and g\hich\af2\dbch\af31505\loch\f2 enerates a longer report.
+\par \hich\af2\dbch\af31505\loch\f2         time to\hich\af2\dbch\af31505\loch\f2  complete and generates a longer report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of DGU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value               \hich\af2\dbch\af31505\loch\f2  False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on: Computer System, Disks, Processor and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r may require the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   This parameter may require the script be run from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain Admin
 \par \hich\af2\dbch\af31505\loch\f2         or Local Administrator).
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it\hich\af2\dbch\af31505\loch\f2  takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of HW.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hosting [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts, Host \hich\af2\dbch\af31505\loch\f2 Connections and Resources.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for Hosts, Host Connections and Resources.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Host.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Logging [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Give the Configuration Logging report with, by default, details for the previous
+\par \hich\af2\dbch\af31505\loch\f2         Give the Co\hich\af2\dbch\af31505\loch\f2 nfiguration Logging report with, by default, details for the previous
 \par \hich\af2\dbch\af31505\loch\f2         seven days.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled\hich\af2\dbch\af31505\loch\f2  by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -579,14 +578,14 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Format to include a specific time range is "MM/DD/YYYY HH:MM:SS" in 24 hour format.
 \par \hich\af2\dbch\af31505\loch\f2         The double quotes are needed.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default is\hich\af2\dbch\af31505\loch\f2  today's date minus seven days.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SD.
+\par \hich\af2\dbch\af31505\loch\f2         The default is today's date minus seven days.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter ha\hich\af2\dbch\af31505\loch\f2 s an alias of SD.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                ((Get-Date -displayhint date).AddDays(-7))
-\par \hich\af2\dbch\af31505\loch\f2         Accept\hich\af2\dbch\af31505\loch\f2  pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard char\hich\af2\dbch\af31505\loch\f2 acters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -EndDate <DateTime>
 \par \hich\af2\dbch\af31505\loch\f2         End date for the Configuration Logging report.
@@ -601,35 +600,35 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                (Get-Date -displayhint date)
+\par \hich\af2\dbch\af31505\loch\f2         Default \hich\af2\dbch\af31505\loch\f2 value                (Get-Date -displayhint date)
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MachineCatalogs [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Mac\hich\af2\dbch\af31505\loch\f2 hine Catalogs.
+\par \hich\af2\dbch\af31505\loch\f2         Gives detailed information for all machines in all Machine Catalogs.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using the MachineCatalogs parameter can cause the report to take a very long
 \par \hich\af2\dbch\af31505\loch\f2         time to complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both the MachineCatalogs and DeliveryGroups parameters can cause the
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      report to take an extremely long time to complete and generate an exceptionally
+\par \hich\af2\dbch\af31505\loch\f2         report to t\hich\af2\dbch\af31505\loch\f2 ake an extremely long time to complete and generate an exceptionally
 \par \hich\af2\dbch\af31505\loch\f2         long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MC.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Positio\hich\af2\dbch\af31505\loch\f2 n?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?              \hich\af2\dbch\af31505\loch\f2       named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoADPolicies [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD based policy information from\hich\af2\dbch\af31505\loch\f2  the output document.
+\par \hich\af2\dbch\af31505\loch\f2         Excludes all Citrix AD based policy information from the output document.
 \par \hich\af2\dbch\af31505\loch\f2         Includes only Site policies created in Studio.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This switch is useful in large AD environments, where there may be thousands
-\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSVOL from being searched.
+\par \hich\af2\dbch\af31505\loch\f2         of policies, to keep SYSV\hich\af2\dbch\af31505\loch\f2 OL from being searched.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NoAD.
@@ -637,72 +636,72 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoPolicies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes all Site and Citrix AD based policy information from the output document.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause the Policies parameter to\hich\af2\dbch\af31505\loch\f2  be set to False.
+\par \hich\af2\dbch\af31505\loch\f2         Using the NoPolicies parameter will cause \hich\af2\dbch\af31505\loch\f2 the Policies parameter to be set to False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NP.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pi\hich\af2\dbch\af31505\loch\f2 peline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Def\hich\af2\dbch\af31505\loch\f2 ault value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -NoSessions [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Excludes Machine Catalog, Application and Hosting session data from the report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the MaxDetails parameter does not change this s\hich\af2\dbch\af31505\loch\f2 etting.
+\par \hich\af2\dbch\af31505\loch\f2         Usin\hich\af2\dbch\af31505\loch\f2 g the MaxDetails parameter does not change this setting.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of NS.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value\hich\af2\dbch\af31505\loch\f2                 False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Policies [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Give detailed information for both Site and Citrix AD based Policies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Note:\hich\af2\dbch\af31505\loch\f2  The Citrix Group Policy PowerShell module will not load from an elevated
+\par \hich\af2\dbch\af31505\loch\f2         Note: The Citrix Group Pol\hich\af2\dbch\af31505\loch\f2 icy PowerShell module will not load from an elevated
 \par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
 \par \hich\af2\dbch\af31505\loch\f2         If the module is manually imported, the module is not detected from an elevated
 \par \hich\af2\dbch\af31505\loch\f2         PowerShell session.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter \hich\af2\dbch\af31505\loch\f2 can cause the report to take a very long time
+\par \hich\af2\dbch\af31505\loch\f2         Using the Policies parameter can cause the report \hich\af2\dbch\af31505\loch\f2 to take a very long time
 \par \hich\af2\dbch\af31505\loch\f2         to complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         There are three related parameters: Policies, NoPolicies and NoADPolicies.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and pri\hich\af2\dbch\af31505\loch\f2 ority is given to NoPolicies.
+\par \hich\af2\dbch\af31505\loch\f2         Policies and NoPolicies are mutually exclusive and priority is given to NoPolicies.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Using both Policies and NoADPolicies results in only policies created in Studio
 \par \hich\af2\dbch\af31505\loch\f2         being in the output document.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled b\hich\af2\dbch\af31505\loch\f2 y default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of Pol.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard char\hich\af2\dbch\af31505\loch\f2 acters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -StoreFront [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Give detailed information for StoreFront.
+\par \hich\af2\dbch\af31505\loch\f2         Give detailed information for StoreFront.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value            \hich\af2\dbch\af31505\loch\f2     False
+\par \hich\af2\dbch\af31505\loch\f2         Position?   \hich\af2\dbch\af31505\loch\f2                  named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -710,7 +709,7 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is the same as using the following parameters:
-\par \hich\af2\dbch\af31505\loch\f2                 Adm\hich\af2\dbch\af31505\loch\f2 inistrators
+\par \hich\af2\dbch\af31505\loch\f2                 Administrators
 \par \hich\af2\dbch\af31505\loch\f2                 Applications
 \par \hich\af2\dbch\af31505\loch\f2                 DeliveryGroups
 \par \hich\af2\dbch\af31505\loch\f2                 HardWare
@@ -724,31 +723,31 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Does not change the value of NoSessions.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
-\par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
+\par \hich\af2\dbch\af31505\loch\f2         can take a very\hich\af2\dbch\af31505\loch\f2  long time to run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an ali\hich\af2\dbch\af31505\loch\f2 as of MAX.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wild\hich\af2\dbch\af31505\loch\f2 card characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <String>
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Processes a specific section of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Processes a specific section of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Admins (Administrators)
 \par \hich\af2\dbch\af31505\loch\f2                 Apps (Applications)
 \par \hich\af2\dbch\af31505\loch\f2                 AppV
 \par \hich\af2\dbch\af31505\loch\f2                 Catalogs (Machine Catalogs)
 \par \hich\af2\dbch\af31505\loch\f2                 Config (Configuration)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Controllers
+\par \hich\af2\dbch\af31505\loch\f2                 Controllers
 \par \hich\af2\dbch\af31505\loch\f2                 Groups (Delivery Groups)
 \par \hich\af2\dbch\af31505\loch\f2                 Hosting
 \par \hich\af2\dbch\af31505\loch\f2                 Licensing
 \par \hich\af2\dbch\af31505\loch\f2                 Logging
 \par \hich\af2\dbch\af31505\loch\f2                 Policies
-\par \hich\af2\dbch\af31505\loch\f2                 StoreFront
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            StoreFront
 \par \hich\af2\dbch\af31505\loch\f2                 Zones
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
@@ -756,21 +755,21 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Notes:
 \par \hich\af2\dbch\af31505\loch\f2         Using Logging will force the Logging switch to True.
 \par \hich\af2\dbch\af31505\loch\f2         Using Policies will force the Policies switch to True.
-\par \hich\af2\dbch\af31505\loch\f2         If Policies is selected and the NoPolicies switch is used, \hich\af2\dbch\af31505\loch\f2 the script will terminate.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      If Policies is selected and the NoPolicies switch is used, the script will terminate.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -AddDateTi\hich\af2\dbch\af31505\loch\f2 me [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         Time stamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2021-06-01_1800.docx (or .\hich\af2\dbch\af31505\loch\f2 pdf).
+\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2021-06-01_1800.docx (or .pdf).
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ADT.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an \hich\af2\dbch\af31505\loch\f2 alias of ADT.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -778,23 +777,91 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParamete\hich\af2\dbch\af31505\loch\f2 r>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is u\hich\af2\dbch\af31505\loch\f2 sed when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder\hich\af2\dbch\af31505\loch\f2  from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?    \hich\af2\dbch\af31505\loch\f2                 named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
+\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information \hich\af2\dbch\af31505\loch\f2 about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Pos\hich\af2\dbch\af31505\loch\f2 ition?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
+\par \hich\af2\dbch\af31505\loch\f2         Thi\hich\af2\dbch\af31505\loch\f2 s parameter is set True if no other output format is selected.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildc\hich\af2\dbch\af31505\loch\f2 ard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft\hich\af2\dbch\af31505\loch\f2  Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013\hich\af2\dbch\af31505\loch\f2 /2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Re\hich\af2\dbch\af31505\loch\f2 quired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -802,110 +869,42 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troublesh\hich\af2\dbch\af31505\loch\f2 ooting.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover P\hich\af2\dbch\af31505\loch\f2 age, if the Cover Page has the Email field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
+\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         Text file is placed in the same folder from where the script is run.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by\hich\af2\dbch\af31505\loch\f2  default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charac\hich\af2\dbch\af31505\loch\f2 ters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value   \hich\af2\dbch\af31505\loch\f2              False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Require\hich\af2\dbch\af31505\loch\f2 d?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to\hich\af2\dbch\af31505\loch\f2  use for the Cover Page, if the Cover Page has the Address field.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Fi\hich\af2\dbch\af31505\loch\f2 ligree (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter\hich\af2\dbch\af31505\loch\f2  is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias \hich\af2\dbch\af31505\loch\f2 of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field\hich\af2\dbch\af31505\loch\f2 :
-\par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a \hich\af2\dbch\af31505\loch\f2 Fax field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with th\hich\af2\dbch\af31505\loch\f2 e MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard c\hich\af2\dbch\af31505\loch\f2 haracters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the\hich\af2\dbch\af31505\loch\f2  Cover Page.
+\par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\Use\hich\af2\dbch\af31505\loch\f2 rInfo\\Company, whichever is populated
 \par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
@@ -915,7 +914,7 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyPho\hich\af2\dbch\af31505\loch\f2 ne <String>
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
@@ -926,26 +925,26 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  Default value
+\par \hich\af2\dbch\af31505\loch\f2         Posi\hich\af2\dbch\af31505\loch\f2 tion?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
-\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
-\par \hich\af2\dbch\af31505\loch\f2         (default cover pages i\hich\af2\dbch\af31505\loch\f2 n Word en-US)
+\par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are sup\hich\af2\dbch\af31505\loch\f2 ported.
+\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in\hich\af2\dbch\af31505\loch\f2  2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
-\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works\hich\af2\dbch\af31505\loch\f2 )
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Contrast (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
@@ -953,48 +952,48 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 ma\hich\af2\dbch\af31505\loch\f2 nually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 m\hich\af2\dbch\af31505\loch\f2 anually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2\hich\af2\dbch\af31505\loch\f2 010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word \hich\af2\dbch\af31505\loch\f2 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
+\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word\hich\af2\dbch\af31505\loch\f2  2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                \hich\af2\dbch\af31505\loch\f2  Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (W\hich\af2\dbch\af31505\loch\f2 ord 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
-\par \hich\af2\dbch\af31505\loch\f2         Th\hich\af2\dbch\af31505\loch\f2 is parameter has an alias of CP.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?       \hich\af2\dbch\af31505\loch\f2              false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $e\hich\af2\dbch\af31505\loch\f2 nv:username
+\par \hich\af2\dbch\af31505\loch\f2         User name to use for the Cover\hich\af2\dbch\af31505\loch\f2  Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value             \hich\af2\dbch\af31505\loch\f2    $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Positio\hich\af2\dbch\af31505\loch\f2 n?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -1002,10 +1001,10 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Posi\hich\af2\dbch\af31505\loch\f2 tion?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard character\hich\af2\dbch\af31505\loch\f2 s?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
@@ -1014,27 +1013,27 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?      \hich\af2\dbch\af31505\loch\f2  false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -From <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the us\hich\af2\dbch\af31505\loch\f2 ername for the From email address.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?     \hich\af2\dbch\af31505\loch\f2                named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    name\hich\af2\dbch\af31505\loch\f2 d
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input\hich\af2\dbch\af31505\loch\f2 ?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
@@ -1042,19 +1041,23 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                  \hich\af2\dbch\af31505\loch\f2   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVaria\hich\af2\dbch\af31505\loch\f2 ble. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorV\hich\af2\dbch\af31505\loch\f2 ariable, WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4143801 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 
+HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4143801 {\*\datafield 
+00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid4143801 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
+\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
+\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this scri\hich\af2\dbch\af31505\loch\f2 pt.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
@@ -1066,9 +1069,10 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inv5ntory.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.46
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4143801 \hich\af2\dbch\af31505\loch\f2 7}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: January 24, 2021
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: January }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4143801 \hich\af2\dbch\af31505\loch\f2 30}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
+\hich\af2\dbch\af31505\loch\f2 , 2021
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1078,13 +1082,13 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2  all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURREN\hich\af2\dbch\af31505\loch\f2 T_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     The computer running the scri\hich\af2\dbch\af31505\loch\f2 pt for the AdminAddress.
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    The computer running the script for the AdminAddress.
 \par 
 \par 
 \par 
@@ -1095,13 +1099,13 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 U}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 se}{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2  all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for th\hich\af2\dbch\af31505\loch\f2 e Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     DDC01 for the AdminAddress.
 \par 
@@ -1113,12 +1117,12 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
- all default val\hich\af2\dbch\af31505\loch\f2 ues and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
-\hich\af2\dbch\af31505\loch\f2  the document as a PDF file.
+ all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2  the docum
+\hich\af2\dbch\af31505\loch\f2 ent as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administra\hich\af2\dbch\af31505\loch\f2 tor
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1135,33 +1139,33 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  the document as a formatted text file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserI\hich\af2\dbch\af31505\loch\f2 nfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator\hich\af2\dbch\af31505\loch\f2  for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ------------------\hich\af2\dbch\af31505\loch\f2 -------- EXAMPLE 5 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -HTML
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all default values and save}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  the document as an HTML file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offi\hich\af2\dbch\af31505\loch\f2 ce\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
 \par 
 \par 
 \par 
@@ -1170,15 +1174,15 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MachineCatalogs
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all m\hich\af2\dbch\af31505\loch\f2 achines in all Machine Catalogs.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $\hich\af2\dbch\af31505\loch\f2 env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Na\hich\af2\dbch\af31505\loch\f2 me.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1187,17 +1191,17 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.p\hich\af2\dbch\af31505\loch\f2 s1 -DeliveryGroups
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -DeliveryGroups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsof\hich\af2\dbch\af31505\loch\f2 t\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1208,12 +1212,12 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -DeliveryGroupsUtilization
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilizati\hich\af2\dbch\af31505\loch\f2 on details for all Desktop (Delivery) Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with utilization details for all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInf\hich\af2\dbch\af31505\loch\f2 o\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl W\hich\af2\dbch\af31505\loch\f2 ebster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1227,14 +1231,14 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -DeliveryGroups -MachineCatalogs
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs and
-\par \hich\af2\dbch\af31505\loch\f2     all desktops in all Deliv\hich\af2\dbch\af31505\loch\f2 ery Groups.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full d\hich\af2\dbch\af31505\loch\f2 etails for all machines in all Machine Catalogs and
+\par \hich\af2\dbch\af31505\loch\f2     all desktops in all Delivery Groups.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Admini\hich\af2\dbch\af31505\loch\f2 strator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micro\hich\af2\dbch\af31505\loch\f2 soft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1247,10 +1251,10 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Applications
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Creates a report with full details for all applications.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all applications.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1262,21 +1266,21 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 11 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 11 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Policies.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator fo\hich\af2\dbch\af31505\loch\f2 r the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
 \par 
@@ -1285,15 +1289,15 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -NoPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2  report with no Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $e\hich\af2\dbch\af31505\loch\f2 nv:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1302,14 +1306,14 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -NoADPolicies
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.p\hich\af2\dbch\af31505\loch\f2 s1 -NoADPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a \hich\af2\dbch\af31505\loch\f2 report with no Citrix AD based Policy information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with no Citrix AD based Policy information.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="C\hich\af2\dbch\af31505\loch\f2 arl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1328,12 +1332,12 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURREN\hich\af2\dbch\af31505\loch\f2 T_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
@@ -1344,14 +1348,14 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Administrators
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Administrator Scopes and Roles.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Admini\hich\af2\dbch\af31505\loch\f2 strator Scopes and Roles.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 U\hich\af2\dbch\af31505\loch\f2 ses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
-\hich\af2\dbch\af31505\loch\f2  all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
+ all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Co\hich\af2\dbch\af31505\loch\f2 mmon\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:userna\hich\af2\dbch\af31505\loch\f2 me = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1362,41 +1366,41 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate 01/01/2021 -EndDate 01/31/2021
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Loggi\hich\af2\dbch\af31505\loch\f2 ng -StartDate 01/01/2021 -EndDate 01/31/2021
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the dates 01/01/2021 through
 \par \hich\af2\dbch\af31505\loch\f2     01/31/2021.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_US\hich\af2\dbch\af31505\loch\f2 ER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate "06/01\hich\af2\dbch\af31505\loch\f2 /2021 10:00:00" -EndDate
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate "06/01/2021 10:00:00" -EndDate
 \par \hich\af2\dbch\af31505\loch\f2     "06/01/2021 14:00:00"
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging details for the time range
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configuration Logging \hich\af2\dbch\af31505\loch\f2 details for the time range
 \par \hich\af2\dbch\af31505\loch\f2     06/01/2021 10:00:00AM through 06/01/2021 02:00:00PM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must b\hich\af2\dbch\af31505\loch\f2 e either 00 or 59.
+\par \hich\af2\dbch\af31505\loch\f2     Narrowing the report down to seconds does not work. Seconds must be either 00 or 59.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Comm\hich\af2\dbch\af31505\loch\f2 on\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username \hich\af2\dbch\af31505\loch\f2 = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1409,17 +1413,17 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Hosting
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Hosts, Host Connections}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
-\hich\af2\dbch\af31505\loch\f2  and Resources.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for Hosts, Host \hich\af2\dbch\af31505\loch\f2 Connections}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2  and Resources.
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\\hich\af2\dbch\af31505\loch\f2 Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:usern\hich\af2\dbch\af31505\loch\f2 ame = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for t\hich\af2\dbch\af31505\loch\f2 he Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
@@ -1427,14 +1431,14 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -StoreFront
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory.ps1 -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for StoreFront.
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2  al
-\hich\af2\dbch\af31505\loch\f2 l Default values.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
+ all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\O\hich\af2\dbch\af31505\loch\f2 ffice\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1446,12 +1450,12 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MachineCatalogs -Delivery\hich\af2\dbch\af31505\loch\f2 Groups -Applications
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MachineCatalogs -DeliveryGroups -Applications
 \par \hich\af2\dbch\af31505\loch\f2     -Policies -Hosting -StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
-\par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Groups
+\par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delive\hich\af2\dbch\af31505\loch\f2 ry Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2  and Resources
@@ -1462,7 +1466,7 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env\hich\af2\dbch\af31505\loch\f2 :username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1471,13 +1475,13 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 21 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MC -DG -Apps -Policies -Hosting
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all:
 \par \hich\af2\dbch\af31505\loch\f2         Machines in all Machine Catalogs
-\par \hich\af2\dbch\af31505\loch\f2         Desktops in all\hich\af2\dbch\af31505\loch\f2  Delivery Groups
+\par \hich\af2\dbch\af31505\loch\f2         Desktops in all Delivery Grou\hich\af2\dbch\af31505\loch\f2 ps
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
 \par \hich\af2\dbch\af31505\loch\f2         Hosts, Host Connections and Resources
@@ -1485,7 +1489,7 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
  all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwa\hich\af2\dbch\af31505\loch\f2 re\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1501,7 +1505,7 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 :
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Con\hich\af2\dbch\af31505\loch\f2 sulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         Controller named DDC01 for the AdminAddress.
@@ -1511,7 +1515,7 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSS\hich\af2\dbch\af31505\loch\f2 cript .\\XD7_Inventory.ps1 -CN "Carl Webster Consulting" -CP "Mod" -UN
 \par \hich\af2\dbch\af31505\loch\f2     "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 :
@@ -1525,34 +1529,34 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Sherlock Holmes Consu\hich\af2\dbch\af31505\loch\f2 lting"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 -CompanyAddress "221B Baker Street, London, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 England"}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  }{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 -CompanyFax "+44 1753 276600" \hich\af2\dbch\af31505\loch\f2 -CompanyPhone "+4\hich\af2\dbch\af31505\loch\f2 4 1753 276200"
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 -CompanyFax "+44 1753 276600" -CompanyPhone "+44 1753 276200"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 :
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Exposure for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Expos\hich\af2\dbch\af31505\loch\f2 ure for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 27\hich\af2\dbch\af31505\loch\f2 6600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Comp\hich\af2\dbch\af31505\loch\f2 a}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 n}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 y Phone.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Compa}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 n}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
+\hich\af2\dbch\af31505\loch\f2 y Phone.
 \par 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 25 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------\hich\af2\dbch\af31505\loch\f2 ------- EXAMPLE 25 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\XD7_Inventory.ps1 -CompanyName "Sherlock Holmes Consulting" 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Fac\hich\af2\dbch\af31505\loch\f2 et -UserName "Dr. Watson" \hich\af2\dbch\af31505\loch\f2 -CompanyEmail SuperSleuth@SherlockHolmes.com
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson" -CompanyEmail SuperSleuth@SherlockHolmes.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 :
 \par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Comp\hich\af2\dbch\af31505\loch\f2 a}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 n}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Compa}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 n}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 y Email.
 \par 
 \par 
@@ -1564,19 +1568,19 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Mi\hich\af2\dbch\af31505\loch\f2 crosoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\User\hich\af2\dbch\af31505\loch\f2 Info\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Pag\hich\af2\dbch\af31505\loch\f2 e format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
-\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
+\par \hich\af2\dbch\af31505\loch\f2     Time stamp is in\hich\af2\dbch\af31505\loch\f2  the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2021 at 6PM is 2021-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2021-06-01_1800.\hich\af2\dbch\af31505\loch\f2 docx
+\par \hich\af2\dbch\af31505\loch\f2     Output filename will be XD7SiteName_2021-06-01_1800.docx
 \par 
 \par 
 \par 
@@ -1587,14 +1591,14 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInf\hich\af2\dbch\af31505\loch\f2 o\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator f\hich\af2\dbch\af31505\loch\f2 or the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     Time stamp is in the format of yyyy-MM-dd_HHmm.
@@ -1604,12 +1608,12 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 28 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Hardware
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2  all default 
-\hich\af2\dbch\af31505\loch\f2 values.
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
+ all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
@@ -1622,22 +1626,22 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 29 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 29 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Folder \\\\FileServer\\Share\hich\af2\dbch\af31505\loch\f2 Name
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrato\hich\af2\dbch\af31505\loch\f2 r
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Output file will be saved in the path \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     Output file wi\hich\af2\dbch\af31505\loch\f2 ll be saved in the path \\\\FileServer\\ShareName
 \par 
 \par 
 \par 
@@ -1648,13 +1652,13 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
  all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover P\hich\af2\dbch\af31505\loch\f2 age format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
 \par 
@@ -1663,14 +1667,14 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 31 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MaxDet\hich\af2\dbch\af31505\loch\f2 ails
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
- all Default values.
+ all Default valu\hich\af2\dbch\af31505\loch\f2 es.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrato\hich\af2\dbch\af31505\loch\f2 r
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1679,16 +1683,16 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         Administrators      = True
 \par \hich\af2\dbch\af31505\loch\f2         Applications        = True
-\par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      = True
+\par \hich\af2\dbch\af31505\loch\f2         DeliveryGroups      =\hich\af2\dbch\af31505\loch\f2  True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare            = True
 \par \hich\af2\dbch\af31505\loch\f2         Hosting             = True
 \par \hich\af2\dbch\af31505\loch\f2         Logging             = True
 \par \hich\af2\dbch\af31505\loch\f2         MachineCatalogs     = True
 \par \hich\af2\dbch\af31505\loch\f2         Policies            = True
-\par \hich\af2\dbch\af31505\loch\f2         Sto\hich\af2\dbch\af31505\loch\f2 reFront          = True
+\par \hich\af2\dbch\af31505\loch\f2         StoreFront          = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NoPolicies          = False
-\par \hich\af2\dbch\af31505\loch\f2         Section             = "All"
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Section             = "All"
 \par 
 \par 
 \par 
@@ -1697,22 +1701,22 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Dev -ScriptInfo -Log
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2  all Defau
-\hich\af2\dbch\af31505\loch\f2 lt values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 Uses}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
+ all Default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Us\hich\af2\dbch\af31505\loch\f2 erInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the \hich\af2\dbch\af31505\loch\f2 Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV1InventoryScriptErrors_yyyy-MM-dd_HHmm.txt that
 \par \hich\af2\dbch\af31505\loch\f2     contains up to the last 250 errors reported by the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named XAXDV1InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
-\par \hich\af2\dbch\af31505\loch\f2     contains all the script \hich\af2\dbch\af31505\loch\f2 parameters and other basic information.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a text file named X\hich\af2\dbch\af31505\loch\f2 AXDV1InventoryScriptInfo_yyyy-MM-dd_HHmm.txt that
+\par \hich\af2\dbch\af31505\loch\f2     contains all the script parameters and other basic information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a text file for transcript logging named
 \par \hich\af2\dbch\af31505\loch\f2     XDV1DocScriptTranscript_yyyy-MM-dd_HHmm.txt.
@@ -1720,16 +1724,15 @@ f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 33 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- \hich\af2\dbch\af31505\loch\f2 EXAMPLE 33 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1\hich\af2\dbch\af31505\loch\f2  -SmtpServer mail.domain.tld -From
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer mail.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     XDAdmin@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mail.domain.tld, sending from XDAdmin@domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     and sending to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     and s\hich\af2\dbch\af31505\loch\f2 ending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 an\hich\af2\dbch\af31505\loch\f2 d does not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 I}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
 f the current user's credentials are not valid to send an email, the script prompts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  
@@ -1740,37 +1743,36 @@ f the current user's credentials are not valid to send an email, the script prom
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 34 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer mailrelay.domain.tld -From
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer mail\hich\af2\dbch\af31505\loch\f2 relay.domain.tld -From
 \par \hich\af2\dbch\af31505\loch\f2     Anonymous@domain.tld -To ITGroup@domain.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***SENDING UNAUTHENTICATED EMAIL***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script u\hich\af2\dbch\af31505\loch\f2 ses the email server mailrelay.domain.tld, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server mailrelay.domain.tld, sending from }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 anonymous@domain.tld and sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an unauthenticated email using an email relay server requires the From email
+\par \hich\af2\dbch\af31505\loch\f2     To s\hich\af2\dbch\af31505\loch\f2 end an unauthenticated email using an email relay server requires the From email
 \par \hich\af2\dbch\af31505\loch\f2     account to use the name Anonymous.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script\hich\af2\dbch\af31505\loch\f2  uses the default SMTP port 25 and does not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and does not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/2956491?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.\hich\af2\dbch\af31505\loch\f2 google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000374}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en"
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you \hich\af2\dbch\af31505\loch\f2 may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email u\hich\af2\dbch\af31505\loch\f2 sing a Gmail or g-suite account, you may have to turn ON the "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script generates an anonymous, s\hich\af2\dbch\af31505\loch\f2 ecure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par 
@@ -1780,22 +1782,22 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer
 \par \hich\af2\dbch\af31505\loch\f2     labaddomain-com.mail.protection.outlook.com -UseSSL -From
-\par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2     SomeEma\hich\af2\dbch\af31505\loch\f2 ilAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  ***OFFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2 HYPERLINK "https://docs.m\hich\af2\dbch\af31505\loch\f2 
-icrosoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3"\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3
-}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000373}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/\hich\af2\dbch\af31505\loch\f2 
+mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    The script uses the email server labaddomain-com.mail.protection.outlook.com, sending
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server labaddomain-com.mail.protection.ou\hich\af2\dbch\af31505\loch\f2 tlook.com, sending
 \par \hich\af2\dbch\af31505\loch\f2     from SomeEmailAddress@labaddomain.com and sending to ITGroupDL@labaddomain.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the default SMTP port 25 and SSL.
@@ -1803,16 +1805,15 @@ icrosoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifuncti
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     --------------------\hich\af2\dbch\af31505\loch\f2 ------ EXAMPLE 36 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 36 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\XD7_Inventory.ps1 -SmtpServer smtp.office365.com -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.office365.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@carlwebster.com and sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     webster@carlwe\hich\af2\dbch\af31505\loch\f2 bster.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 If the current us\hich\af2\dbch\af31505\loch\f2 er's credentials are not valid to send an email, the script prompts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 
-\hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 the user to enter valid credentials.
 \par 
 \par 
@@ -1820,21 +1821,20 @@ icrosoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifuncti
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 37 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer smtp.gmail.com -Sm\hich\af2\dbch\af31505\loch\f2 tpPort 587 -UseSSL
-\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -SmtpServer smtp.gmail.com -SmtpPort 587 -UseSSL
 \par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "Le\hich\af2\dbch\af31505\loch\f2 ss
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
+\par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
 \par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com and sending to ITGroup@carlwebster.com.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2    }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 
-If the current user's credentials are not valid to send an email, the script prompts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 the user\hich\af2\dbch\af31505\loch\f2  to enter valid credentials.
+If the current user's credentials\hich\af2\dbch\af31505\loch\f2  are not valid to send an email, the script prompts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14300739\charrsid14300739 \hich\af2\dbch\af31505\loch\f2 the user to enter valid credentials.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 RELATED LINKS
@@ -1957,8 +1957,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000000068
-c29c9af2d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000000d7
+5feb1cf7d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/XD7_Script_ChangeLog.txt
+++ b/XD7_Script_ChangeLog.txt
@@ -3,6 +3,14 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
+#Version 1.47 30-Jan-2021
+#	Added getting hardware information for the license server when -Hardware is used
+#	Added getting hardware information for the SQL Server(s) when -Hardware is used
+#	Changed all Write-Verbose $(Get-Date) to add -Format G to put the dates in the user's locale
+#	Fixed duplicate item in the HTML output for Machine Catalogs
+#	Fixed wrong variable name when getting the Monitoring database mirroring information
+#	Updated the WMI query code for getting the Power Plan to handle the case where the Power Plan data is missing in the WMI repository
+
 #Version 1.46 24-Jan-2021
 #	Added error checking in Function Check-NeededPSSnapins (Requested by Guy Leech)
 #	Added to the Computer Hardware section, the server's Power Plan


### PR DESCRIPTION
#Version 1.47 30-Jan-2021
#	Added getting hardware information for the license server when -Hardware is used
#	Added getting hardware information for the SQL Server(s) when -Hardware is used
#	Changed all Write-Verbose $(Get-Date) to add -Format G to put the dates in the user's locale
#	Fixed duplicate item in the HTML output for Machine Catalogs
#	Fixed wrong variable name when getting the Monitoring database mirroring information
#	Updated the WMI query code for getting the Power Plan to handle the case where the Power Plan data is missing in the WMI repository