### PR TITLE
Final update for 1.52

### DIFF
--- a/XD7_Inventory_V1_ReadMe.rtf
+++ b/XD7_Inventory_V1_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -52,27 +52,27 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 {\s23\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
 \sbasedon0 \snext23 \slink24 \styrsid7677730 header;}{\*\cs24 \additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \f43\fs24 \sbasedon10 \slink23 \slocked \styrsid7677730 Header Char;}{\s25\ql \li0\ri0\nowidctlpar
 \tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext25 \slink26 \styrsid7677730 footer;}{\*\cs26 
-\additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \f43\fs24 \sbasedon10 \slink25 \slocked \styrsid7677730 Footer Char;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1
-\levelspace360\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0
-{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
+\additive \rtlch\fcs1 \af0\afs24 \ltrch\fcs0 \f43\fs24 \sbasedon10 \slink25 \slocked \styrsid7677730 Footer Char;}}{\*\listtable{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360
+\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
+\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698703\'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698713\'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698715\'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698703\'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698713\'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext
-\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-154213762\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0
-\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0
-\levelindent0{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698715\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid319386001}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1
+\levelspace0\levelindent0{\leveltext\leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0
+{\leveltext\leveltemplateid67698713\'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
 \leveltemplateid67698715\'02\'02.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li2160\lin2160 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext\leveltemplateid67698703
 \'02\'03.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713
 \'02\'04.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li3600\lin3600 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
 \'02\'05.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li4320\lin4320 }{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698703
 \'02\'06.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5040\lin5040 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698713
 \'02\'07.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698715
-\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-183201164\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0
-\levelindent0{\leveltext\leveltemplateid2071627316\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0
-{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
+\'02\'08.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-180\li6480\lin6480 }{\listname ;}\listid1818835589}{\list\listtemplateid-1\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat0\levelspace0\levelindent0
+{\leveltext\leveltemplateid2071627316\'01\u-3913 ?;}{\levelnumbers;}\loch\af3\hich\af3\dbch\af31505\fbias0 \fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace0\levelindent0{\leveltext
+\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693
 \'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li2160\lin2160 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698689\'01\u-3913 ?;}{\levelnumbers;}
 \f3\fbias0 \fi-360\li2880\lin2880 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li3600\lin3600 }
 {\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li4320\lin4320 }{\listlevel\levelnfc23\levelnfcn23
@@ -80,22 +80,22 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \levelstartat1\lvltentative\levelspace0\levelindent0{\leveltext\leveltemplateid67698691\'01o;}{\levelnumbers;}\f2\fbias0 \fi-360\li5760\lin5760 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\lvltentative\levelspace0
 \levelindent0{\leveltext\leveltemplateid67698693\'01\u-3929 ?;}{\levelnumbers;}\f10\fbias0 \fi-360\li6480\lin6480 }{\listname ;}\listid1955283310}}{\*\listoverridetable{\listoverride\listid1955283310\listoverridecount0\ls1}{\listoverride\listid1818835589
 \listoverridecount0\ls2}{\listoverride\listid319386001\listoverridecount0\ls3}}{\*\rsidtbl \rsid2070\rsid17168\rsid219208\rsid265763\rsid677819\rsid1076041\rsid1146462\rsid1654655\rsid1853201\rsid2579094\rsid2584542\rsid2902416\rsid2978753\rsid3557177
-\rsid3761251\rsid3830441\rsid3831187\rsid4143801\rsid4619633\rsid4925376\rsid5267713\rsid5664854\rsid6053627\rsid6237392\rsid6258287\rsid6509366\rsid6885713\rsid7282340\rsid7367214\rsid7677730\rsid7687390\rsid7746862\rsid7763859\rsid7809154\rsid7892821
-\rsid8394203\rsid8410782\rsid8473952\rsid8928184\rsid9112866\rsid9186743\rsid9372083\rsid9380266\rsid9644665\rsid9648170\rsid9986361\rsid10033903\rsid10638569\rsid11148983\rsid11353962\rsid11410367\rsid11488686\rsid11551746\rsid11809962\rsid12216897
-\rsid12256862\rsid12800250\rsid12801149\rsid13248665\rsid13308089\rsid13663721\rsid13853169\rsid13987238\rsid13989223\rsid14298582\rsid14300739\rsid14697282\rsid14764273\rsid14881286\rsid15028178\rsid15424297\rsid15739805\rsid15757842\rsid15955795
-\rsid16207041\rsid16267726\rsid16269241\rsid16276870\rsid16283129\rsid16408172\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info
-{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2022\mo2\dy13\hr7\min35}{\version54}{\edmins11799}{\nofpages27}{\nofwords8416}{\nofchars47974}{\nofcharsws56278}{\vern41}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word
-/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid3743358\rsid3761251\rsid3830441\rsid3831187\rsid4143801\rsid4619633\rsid4925376\rsid5267713\rsid5664854\rsid6053627\rsid6237392\rsid6258287\rsid6509366\rsid6885713\rsid7282340\rsid7367214\rsid7677730\rsid7687390\rsid7746862\rsid7763859\rsid7809154
+\rsid7892821\rsid8394203\rsid8410782\rsid8473952\rsid8928184\rsid9112866\rsid9186743\rsid9372083\rsid9380266\rsid9644665\rsid9648170\rsid9986361\rsid10033903\rsid10638569\rsid11148983\rsid11353962\rsid11410367\rsid11488686\rsid11551746\rsid11809962
+\rsid12216897\rsid12256862\rsid12800250\rsid12801149\rsid13248665\rsid13308089\rsid13663721\rsid13853169\rsid13987238\rsid13989223\rsid14298582\rsid14300739\rsid14697282\rsid14764273\rsid14881286\rsid15028178\rsid15424297\rsid15739805\rsid15757842
+\rsid15955795\rsid16207041\rsid16267726\rsid16269241\rsid16276870\rsid16283129\rsid16404357\rsid16408172\rsid16517051\rsid16597410}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0
+\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2022\mo3\dy26\hr15\min21}{\version55}{\edmins11800}{\nofpages27}{\nofwords8415}{\nofchars47972}{\nofcharsws56275}{\vern43}}{\*\xmlnstbl {\xmlns1 http://schemas.microso
+ft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale111\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0MTQ3MDQzN7I0MTY0MDVQ0lEKTi0uzszPAymwqAUAntfWXSwAAAA=}}{\*\ftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7677730 \rtlch\fcs1 
-\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5664854 \chftnsep 
+\af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3743358 \chftnsep 
 \par }}{\*\ftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7677730 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5664854 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3743358 \chftnsepc 
 \par }}{\*\aftnsep \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7677730 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5664854 \chftnsep 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3743358 \chftnsep 
 \par }}{\*\aftnsepc \ltrpar \pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid7677730 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
-\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid5664854 \chftnsepc 
+\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid3743358 \chftnsepc 
 \par }}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\headerl \ltrpar \pard\plain \ltrpar\s23\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid7677730 
 \par }}{\headerr \ltrpar \pard\plain \ltrpar\s23\ql \li0\ri0\nowidctlpar\tqc\tx4680\tqr\tx9360\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -156,24 +156,24 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \hich\af37\dbch\af31505\loch\f37  remotely, }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 there are two choices: install }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 
 \hich\af37\dbch\af31505\loch\f37 Citrix Studio }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 or manually install the PowerShell snapins.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid6258287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 Install Studio from the full XenDesktop 7.x installation media. }{
-\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 Installing Citrix Studio install}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7677730 \hich\af37\dbch\af31505\loch\f37 s}{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37  all the necessary PowerShell snapins.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 b.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 Install the PowerShell sn
-\hich\af37\dbch\af31505\loch\f37 apins individually.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37 
- Depending on the bitness of the computer, from the full XenDesktop 7.x installation media, install the following files from either x64 or x86 (?? is either 86 or 64):}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid6258287\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 Install Studio from th\hich\af37\dbch\af31505\loch\f37 
+e full XenDesktop 7.x installation media. }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37 Installing Citrix Studio install}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid7677730 
+\hich\af37\dbch\af31505\loch\f37 s}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid677819 \hich\af37\dbch\af31505\loch\f37  all the necessary PowerShell snapins.
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 b.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 \hich\af37\dbch\af31505\loch\f37 
+Install the PowerShell snapins individually.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Depending on the bitness of the computer, from the full XenDesktop 7.x installation media, ins
+\hich\af37\dbch\af31505\loch\f37 tall the following files from either x64 or x86 (?? is either 86 or 64):}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid6258287 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 i.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\ADIdentity_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37 ii.\tab}\hich\af37\dbch\af31505\loch\f37 (Only for XenDesktop 7.6}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid16597410 \hich\af37\dbch\af31505\loch\f37  and later}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37 ) }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 
 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Analytics_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Broker_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 iii.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 C
+\hich\af37\dbch\af31505\loch\f37 itrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Broker_PowerShell_SnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 iv.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Configuration_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 v.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 C
-\hich\af37\dbch\af31505\loch\f37 itrix}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\ConfigurationLogging_PowerShell_SnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 v.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\ConfigurationLogging_PowerShell_SnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 vi.\tab}}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix}{\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 \hich\af37\dbch\af31505\loch\f37  Desktop Delivery Controller\\Del}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 egatedAdmin_PowerShellSnapIn_x??}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 
@@ -182,13 +182,14 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid3761251 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 viii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid219208\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Host_PowerShell_SnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 ix.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\MachineCreation_PowerShellSnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 ix.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\MachineCreatio\hich\af37\dbch\af31505\loch\f37 
+n_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 x.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Monitor_PowerShellSnapIn_x??
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xi.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Storefront_P\hich\af37\dbch\af31505\loch\f37 
-owerShellSnapIn_x??
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xi.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Desktop Delivery Controller\\Storefront_PowerShellSnapIn_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xii.\tab}\hich\af37\dbch\af31505\loch\f37 Citrix Policy\\CitrixGroupPolicyManagement_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xiii.\tab}}\pard \ltrpar\s17\ql \fi-180\li2160\ri0\sa200\sl276\slmult1
-\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 DesktopStudio\\PxAppV_Studio_PowershellSnapin_x??
+\nowidctlpar\wrapdefault\faauto\ls2\ilvl2\rin0\lin2160\itap0\pararsid3761251\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 DesktopStudio\\PxAppV_Studio_Powershell
+\hich\af37\dbch\af31505\loch\f37 Snapin_x??
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid219208 \hich\af37\dbch\af31505\loch\f37 xiv.\tab}\hich\af37\dbch\af31505\loch\f37 Licensing\\LicensingAdmin_PowerShellSnapIn_x??
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid9112866\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid9112866 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid16597410 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
@@ -333,24 +334,24 @@ XD7_Inventory.ps1 [-AdminAddress <String>] [-Administrators] }{\rtlch\fcs1 \af2\
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a Controller. This script was developed and run
 \par \hich\af2\dbch\af31505\loch\f2     from a Windows 8.1 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     You can run this script remotely using the -AdminAddress (AA) parameter.
+\par \hich\af2\dbch\af31505\loch\f2     You can run this script r\hich\af2\dbch\af31505\loch\f2 emotely using the -AdminAddress (AA) parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     This script supports versions of XenApp/XenDesktop from 7.0 to 7.7.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If you are running XA/XD 7.8 through CVAD 2006, please use:
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/d\hich\af2\dbch\af31505\loch\f2 
-ownloads/download-info/xenappxendesktop-7-8/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/xenapp\hich\af2\dbch\af31505\loch\f2 
+xendesktop-7-8/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90ba4000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+64002d0069006e0066006f002f00780065006e00610070007000780065006e006400650073006b0074006f0070002d0037002d0038002f000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/xenappxendesktop-7-8/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid7677730\charrsid7677730 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If you are running CVAD 2006 and later, please use:
+\par \hich\af2\dbch\af31505\loch\f2     If you are running \hich\af2\dbch\af31505\loch\f2 CVAD 2006 and later, please use:
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-virtual-apps-and-desktops-v3-script/" }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90bd0000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
-64002d0069006e0066006f002f006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d00760033002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}
-}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-virtual-apps-and-desktops-v3-script/}}}\sectd \ltrsect
+64002d0069006e0066006f002f006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d00760033002d007300630072006900700074002f000000795881f43b1d7f48af2c825dc485276300000000a5ab000300
+22}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 https://carlwebster.com/downloads/download-info/citrix-virtual-apps-and-desktops-v3-script/}}}\sectd \ltrsect
 \linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If you are running Citrix Cloud, please use:
@@ -358,13 +359,13 @@ ownloads/download-info/xenappxendesktop-7-8/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fc
  HYPERLINK "https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90be6000000680074007400700073003a002f002f006300610072006c0077006500620073007400650072002e0063006f006d002f0064006f0077006e006c006f006100640073002f0064006f0077006e006c006f006100
 64002d0069006e0066006f002f006300690074007200690078002d0063006c006f00750064002d006300690074007200690078002d007600690072007400750061006c002d0061007000700073002d0061006e0064002d006400650073006b0074006f00700073002d0073006500720076006900630065002f000000795881
-f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 
+f43b1d7f48af2c825dc485276300000000a5ab00030076}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 
 https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps-and-desktops-service/}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     By default, only gives summary information for:
-\par \hich\af2\dbch\af31505\loch\f2         Ad\hich\af2\dbch\af31505\loch\f2 ministrators
+\par \hich\af2\dbch\af31505\loch\f2         Administrators
 \par \hich\af2\dbch\af31505\loch\f2         Applications
-\par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
+\par \hich\af2\dbch\af31505\loch\f2         Delivery Gr\hich\af2\dbch\af31505\loch\f2 oups
 \par \hich\af2\dbch\af31505\loch\f2         Hosting
 \par \hich\af2\dbch\af31505\loch\f2         Logging
 \par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
@@ -372,7 +373,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         StoreFront
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The Summary information is what is shown in the top half of Citrix Studio for:
-\par \hich\af2\dbch\af31505\loch\f2         Machine Catal\hich\af2\dbch\af31505\loch\f2 ogs
+\par \hich\af2\dbch\af31505\loch\f2         Machine Catalogs
 \par \hich\af2\dbch\af31505\loch\f2         Delivery Groups
 \par \hich\af2\dbch\af31505\loch\f2         Applications
 \par \hich\af2\dbch\af31505\loch\f2         Policies
@@ -384,22 +385,22 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     Using the MachineCatalogs parameter can cause the report to take a very long time to
 \par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Using the DeliveryGroups parameter can cause the report to take a very long time to
-\par \hich\af2\dbch\af31505\loch\f2     complete and can g\hich\af2\dbch\af31505\loch\f2 enerate an extremely long report.
+\par \hich\af2\dbch\af31505\loch\f2     Using the Deli\hich\af2\dbch\af31505\loch\f2 veryGroups parameter can cause the report to take a very long time to
+\par \hich\af2\dbch\af31505\loch\f2     complete and can generate an extremely long report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Using both the MachineCatalogs and DeliveryGroups parameters can cause the report to
-\par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to complete and generate an exceptionally long report.
+\par \hich\af2\dbch\af31505\loch\f2     take an extremely long time to compl\hich\af2\dbch\af31505\loch\f2 ete and generate an exceptionally long report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the X\hich\af2\dbch\af31505\loch\f2 enDesktop 7.x Site.
+\par \hich\af2\dbch\af31505\loch\f2     Creates an output file named after the XenDesktop 7.x Site.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF Document includes a Cover Page, Table of Contents, and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Mic\hich\af2\dbch\af31505\loch\f2 rosoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
 \par \hich\af2\dbch\af31505\loch\f2         English
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Finnish
+\par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
 \par \hich\af2\dbch\af31505\loch\f2         Norwegian
@@ -413,23 +414,23 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the address of a XenDesktop controller the PowerShell snapins connects.
 \par \hich\af2\dbch\af31505\loch\f2         This can be provided as a host name or an IP address.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to LocalHost.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of AA.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an a\hich\af2\dbch\af31505\loch\f2 lias of AA.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Requir\hich\af2\dbch\af31505\loch\f2 ed?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                LocalHost
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an H\hich\af2\dbch\af31505\loch\f2 TML file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParam\hich\af2\dbch\af31505\loch\f2 eter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pip\hich\af2\dbch\af31505\loch\f2 eline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
@@ -817,30 +818,30 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Start Date Time in Local Format is a script variable.
 \par \hich\af2\dbch\af31505\loch\f2         Elapsed time is a calculated value.
 \par \hich\af2\dbch\af31505\loch\f2         Domain Name is $env:USERDNSDOMAIN.
-\par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAM\hich\af2\dbch\af31505\loch\f2 E.
+\par \hich\af2\dbch\af31505\loch\f2         Username is $env:USERNAME.
 \par \hich\af2\dbch\af31505\loch\f2         Folder Name is a script variable.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
+\par \hich\af2\dbch\af31505\loch\f2         This\hich\af2\dbch\af31505\loch\f2  parameter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  f\hich\af2\dbch\af31505\loch\f2 alse
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value           \hich\af2\dbch\af31505\loch\f2      False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildca\hich\af2\dbch\af31505\loch\f2 rd characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X t\hich\af2\dbch\af31505\loch\f2 o 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft \hich\af2\dbch\af31505\loch\f2 Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -850,27 +851,27 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if \hich\af2\dbch\af31505\loch\f2 the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Addre\hich\af2\dbch\af31505\loch\f2 ss field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Ion (Dark) (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWO\hich\af2\dbch\af31505\loch\f2 RD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard charact\hich\af2\dbch\af31505\loch\f2 ers?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Email to use for the Cover Page, if the Cover Page has the Email field.
@@ -878,27 +879,27 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
+\par \hich\af2\dbch\af31505\loch\f2     -Comp\hich\af2\dbch\af31505\loch\f2 anyFax <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fa\hich\af2\dbch\af31505\loch\f2 x field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -906,28 +907,28 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         The default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  on the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page, if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2        \hich\af2\dbch\af31505\loch\f2  The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Wor\hich\af2\dbch\af31505\loch\f2 d 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         R\hich\af2\dbch\af31505\loch\f2 equired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -936,55 +937,55 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
-\par \hich\af2\dbch\af31505\loch\f2         (default cover \hich\af2\dbch\af31505\loch\f2 pages in Word en-US)
+\par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't \hich\af2\dbch\af31505\loch\f2 work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't \hich\af2\dbch\af31505\loch\f2 work in 2013 or 2016, mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2                 afte\hich\af2\dbch\af31505\loch\f2 r title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Contrast (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if yo\hich\af2\dbch\af31505\loch\f2 u like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Grid (Word 2010/2013/2016. Works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (W\hich\af2\dbch\af31505\loch\f2 ord 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point\hich\af2\dbch\af31505\loch\f2 )
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
 \par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       resized or font changed to 14 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2             Slice (Dark) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Wor\hich\af2\dbch\af31505\loch\f2 d 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Tr\hich\af2\dbch\af31505\loch\f2 anscend (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default\hich\af2\dbch\af31505\loch\f2  value is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSW\hich\af2\dbch\af31505\loch\f2 ORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value     \hich\af2\dbch\af31505\loch\f2            Sideline
+\par \hich\af2\dbch\af31505\loch\f2         Default value                Sideline
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -995,23 +996,23 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                \hich\af2\dbch\af31505\loch\f2     named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Req\hich\af2\dbch\af31505\loch\f2 uired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  \hich\af2\dbch\af31505\loch\f2 false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
-\par \hich\af2\dbch\af31505\loch\f2         The defau\hich\af2\dbch\af31505\loch\f2 lt is 25.
+\par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1023,15 +1024,15 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
+\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpS\hich\af2\dbch\af31505\loch\f2 erver is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1039,8 +1040,8 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whether \hich\af2\dbch\af31505\loch\f2 to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<S\hich\af2\dbch\af31505\loch\f2 witchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -1051,20 +1052,20 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
-\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         Ou\hich\af2\dbch\af31505\loch\f2 tBuffer, PipelineVariable, and OutVariable. For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable,\hich\af2\dbch\af31505\loch\f2  WarningAction, WarningVariable,
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
 \par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (}{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://go.microsoft.com/fwlink/?LinkID=113216" }{\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b76000000680074007400700073003a002f002f0067006f002e006d006900630072006f0073006f00660074002e0063006f006d002f00660077006c0069006e006b002f003f004c0069006e006b00490044003d003100
-310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}}}
-\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 ).
+310033003200310036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300dc}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 https:/go.microsoft.com/fwlink/?LinkID=113216}
+}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 ).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word, PDF
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a W\hich\af2\dbch\af31505\loch\f2 ord, PDF
 \par \hich\af2\dbch\af31505\loch\f2     plain text, or HTML document.
 \par 
 \par 
@@ -1072,9 +1073,9 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: XD7_Inventory.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16276870 \hich\af2\dbch\af31505\loch\f2 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 1.5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16404357 \hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16276870 \hich\af2\dbch\af31505\loch\f2 February 13, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid16404357 \hich\af2\dbch\af31505\loch\f2 March 26, 2022}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1084,9 +1085,9 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Car\hich\af2\dbch\af31505\loch\f2 l Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
@@ -1096,12 +1097,12 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScri\hich\af2\dbch\af31505\loch\f2 pt >.\\XD7_Inventory.ps1 -AdminAddress DDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -AdminAddress DDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webste\hich\af2\dbch\af31505\loch\f2 r"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Of\hich\af2\dbch\af31505\loch\f2 fice\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1117,14 +1118,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -PDF
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName\hich\af2\dbch\af31505\loch\f2 ="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsof\hich\af2\dbch\af31505\loch\f2 t\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User N\hich\af2\dbch\af31505\loch\f2 ame.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page form\hich\af2\dbch\af31505\loch\f2 at.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     The computer running the script for the AdminAddress.
 \par 
 \par 
@@ -1134,7 +1135,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -TEXT
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as a formatted text fi\hich\af2\dbch\af31505\loch\f2 le.
+\par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves\hich\af2\dbch\af31505\loch\f2  the document as a formatted text file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
@@ -1149,13 +1150,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -HTML
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Invent\hich\af2\dbch\af31505\loch\f2 ory.ps1 -HTML
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Uses all default\hich\af2\dbch\af31505\loch\f2  values and saves the document as an HTML file.
+\par \hich\af2\dbch\af31505\loch\f2     Uses all default values and saves the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Adm\hich\af2\dbch\af31505\loch\f2 inistrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Ca\hich\af2\dbch\af31505\loch\f2 rl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
@@ -1166,13 +1167,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 XD7_Inventory.ps1 -MachineCatalogs
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\XD7_Inventory.ps1 -MachineCatalogs
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all machines in all Machine Catalogs.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1182,13 +1183,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ----------------------\hich\af2\dbch\af31505\loch\f2 ---- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------\hich\af2\dbch\af31505\loch\f2 ---------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -DeliveryGroups
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details for all desktops in all Desktop (Delivery) Groups.
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micros\hich\af2\dbch\af31505\loch\f2 oft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Sof\hich\af2\dbch\af31505\loch\f2 tware\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1313,13 +1314,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Policies -NoADPolicies
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Site policies created in Studio but
+\par \hich\af2\dbch\af31505\loch\f2     C\hich\af2\dbch\af31505\loch\f2 reates a report with full details on Site policies created in Studio but
 \par \hich\af2\dbch\af31505\loch\f2     no Citrix AD}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 -}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 based Policy information.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKE\hich\af2\dbch\af31505\loch\f2 Y_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1329,20 +1330,20 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -----------------\hich\af2\dbch\af31505\loch\f2 --------- EXAMPLE 15 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------------\hich\af2\dbch\af31505\loch\f2 ---- EXAMPLE 15 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Administrators
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a report with full details on Administrator Scopes and Roles.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offic\hich\af2\dbch\af31505\loch\f2 e\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Com\hich\af2\dbch\af31505\loch\f2 mon\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the \hich\af2\dbch\af31505\loch\f2 Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par 
@@ -1352,13 +1353,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Logging -StartDate 01/01/2022 -EndDate 01/31/2022
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a\hich\af2\dbch\af31505\loch\f2  report with Configuration Logging details for the dates 01/01/2022 through
+\par \hich\af2\dbch\af31505\loch\f2     Creates a report with Configur\hich\af2\dbch\af31505\loch\f2 ation Logging details for the dates 01/01/2022 through
 \par \hich\af2\dbch\af31505\loch\f2     01/31/2022.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micro\hich\af2\dbch\af31505\loch\f2 soft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\Us\hich\af2\dbch\af31505\loch\f2 erInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1584,14 +1585,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 28 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 28 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY\hich\af2\dbch\af31505\loch\f2 _CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1601,13 +1602,13 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ------------------\hich\af2\dbch\af31505\loch\f2 -------- EXAMPLE 29 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     ----------------------\hich\af2\dbch\af31505\loch\f2 ---- EXAMPLE 29 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Folder \\\\FileServer\\ShareName
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
@@ -1615,7 +1616,7 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 Output file will be saved in the path \\\\FileServer\\ShareName
+\par \hich\af2\dbch\af31505\loch\f2     Output file w\hich\af2\dbch\af31505\loch\f2 ill be saved in the path \\\\FileServer\\ShareName
 \par 
 \par 
 \par 
@@ -1625,14 +1626,14 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\XD7_Inventory.ps1 -Section Policies
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Uses all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Mi\hich\af2\dbch\af31505\loch\f2 crosoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offic\hich\af2\dbch\af31505\loch\f2 e\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Pag\hich\af2\dbch\af31505\loch\f2 e format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     Processes only the Policies section of the report.
 \par 
 \par 
@@ -1732,15 +1733,15 @@ https://carlwebster.com/downloads/download-info/citrix-cloud-citrix-virtual-apps
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid7677730 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003d6}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab0003d6e7}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid7677730 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the "\hich\af2\dbch\af31505\loch\f2 Less
+\par \hich\af2\dbch\af31505\loch\f2     To send an email using a Gmail or g-suite account, you may have to turn ON the \hich\af2\dbch\af31505\loch\f2 "Less
 \par \hich\af2\dbch\af31505\loch\f2     secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
@@ -1758,15 +1759,15 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     SomeEmailAddress@labaddomain.com -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://docs.microsoft.co\hich\af2\dbch\af31505\loch\f2 
-m/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://docs.microsoft.c\hich\af2\dbch\af31505\loch\f2 
+om/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030020}}}{\fldrslt {\rtlch\fcs1 
 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}
 }}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This uses Opti\hich\af2\dbch\af31505\loch\f2 on 2 from the above link.
+\par \hich\af2\dbch\af31505\loch\f2     This uses O\hich\af2\dbch\af31505\loch\f2 ption 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
@@ -1805,9 +1806,9 @@ m/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-o
 \par \hich\af2\dbch\af31505\loch\f2     *** NOTE ***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script uses the email server smtp.gmail.com on port 587 using SSL, sending from
-\par \hich\af2\dbch\af31505\loch\f2     webster@gmail.com and sending to ITGroup@carlwebster.com.
+\par \hich\af2\dbch\af31505\loch\f2     webster@gm\hich\af2\dbch\af31505\loch\f2 ail.com and sending to ITGroup@carlwebster.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials ar\hich\af2\dbch\af31505\loch\f2 e not valid to send an email, the script prompts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send an email, the script prompts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730 \hich\af2\dbch\af31505\loch\f2  
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7677730\charrsid7677730 \hich\af2\dbch\af31505\loch\f2     the user to enter valid credentials.
 \par 
 \par 
@@ -1931,8 +1932,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000005090
-c17fde20d801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e50000000000000000000000005060
+a70b4f41d801feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/XD7_Script_ChangeLog.txt
+++ b/XD7_Script_ChangeLog.txt
@@ -3,6 +3,17 @@
 #http://www.CarlWebster.com
 # Created on October 20, 2013
 
+#Version 1.52 26-Mar-2022
+#	Fixed bug where Word tables that used a font size of 9 had black backgrounds
+#	In Function OutputSummaryPage, clean up console output and format the HTML and Word/PDF output to match the other CVAD documentation scripts
+#	Replaced all Get-WmiObject with Get-CimInstance
+#	Updated for CVAD 2203/7.33 and CVAD 2206/7.34
+#	Updated the following functions to the latest versions
+#		AddWordTable
+#		SetWordCellFormat
+#		SetWordTableAlternateRowColor
+#	Updated the Policies setting table to match the V3 and Citrix Cloud scripts
+
 #Version 1.51 13-Feb-2022
 #	Changed the date format for the transcript and error log files from yyyy-MM-dd_HHmm format to the FileDateTime format
 #		The format is yyyyMMddTHHmmssffff (case-sensitive, using a 4-digit year, 2-digit month, 2-digit day, 


### PR DESCRIPTION
#Version 1.52 26-Mar-2022
#	Fixed bug where Word tables that used a font size of 9 had black backgrounds
#	In Function OutputSummaryPage, clean up console output and format the HTML and Word/PDF output to match the other CVAD documentation scripts
#	Replaced all Get-WmiObject with Get-CimInstance
#	Updated for CVAD 2203/7.33 and CVAD 2206/7.34
#	Updated the following functions to the latest versions
#		AddWordTable
#		SetWordCellFormat
#		SetWordTableAlternateRowColor
#	Updated the Policies setting table to match the V3 and Citrix Cloud scripts